### PR TITLE
Make content object version metadata copyable ; Diff case when no previous version

### DIFF
--- a/src/components/components/JSONField.js
+++ b/src/components/components/JSONField.js
@@ -1,6 +1,7 @@
 import React, {useState} from "react";
 import {Tabs, TraversableJson} from "elv-components-js";
 import Diff from "../components/Diff";
+import {Copyable} from "./Copyable";
 
 const JSONField = ({json, diffJson, DiffComponent}) => {
   typeof json === "string" ? json = JSON.parse(json || "{}") : json;
@@ -27,7 +28,11 @@ const JSONField = ({json, diffJson, DiffComponent}) => {
   let content;
   switch(viewType) {
     case "raw":
-      content = <pre className="content-object-data">{JSON.stringify(json, null, 2)}</pre>;
+      content = (
+        <pre className="content-object-data">
+          <Copyable copy={JSON.stringify(json, null, 2)} className="raw-data">{JSON.stringify(json, null, 2)}</Copyable>
+        </pre>
+      );
       break;
     case "diff":
       if(diffJson) {

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -325,8 +325,11 @@ class ContentObject extends React.Component {
 
   ObjectVersion({versionHash, latestVersion=false}) {
     let version = this.props.objectStore.object;
+    let hasPreviousVersion = this.props.objectStore.object.versionCount > 0;
+
     if(!latestVersion) {
       version = this.props.objectStore.versions[versionHash];
+      hasPreviousVersion = ((this.props.objectStore.object.versions || []).findIndex(storeVersion => storeVersion === (versionHash)) !== (this.props.objectStore.object.versions || []).length - 1);
     }
 
     if(!version) { return null; }
@@ -364,21 +367,27 @@ class ContentObject extends React.Component {
             <div className="indented">
               <JSONField
                 json={version.meta}
-                DiffComponent={() => {
-                  return (
-                    <AsyncComponent
-                      Load={
-                        async () => {
-                          await this.props.objectStore.ContentObjectVersions({
-                            libraryId: this.props.objectStore.libraryId,
-                            objectId: this.props.objectStore.objectId
-                          });
-                        }
-                      }
-                      render={() => <Diff json={version} />}
-                    />
-                  );
-                }}
+                DiffComponent={
+                  hasPreviousVersion ?
+                    () => {
+                      return (
+                        <AsyncComponent
+                          Load={
+                            async () => {
+                              await this.props.objectStore.ContentObjectVersions({
+                                libraryId: this.props.objectStore.libraryId,
+                                objectId: this.props.objectStore.objectId
+                              });
+                            }
+                          }
+                          render={() => (
+                            hasPreviousVersion ? <Diff json={version} /> : null
+                          )}
+                        />
+                      );
+                    } :
+                    null
+                }
               />
             </div>
           </ToggleSection>

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -380,9 +380,7 @@ class ContentObject extends React.Component {
                               });
                             }
                           }
-                          render={() => (
-                            hasPreviousVersion ? <Diff json={version} /> : null
-                          )}
+                          render={() => <Diff json={version} />}
                         />
                       );
                     } :

--- a/src/static/stylesheets/content.scss
+++ b/src/static/stylesheets/content.scss
@@ -45,6 +45,19 @@
 
 .content-object-data {
   margin: 20px 0;
+
+  .copyable {
+    &.raw-data {
+      display: block;
+      position: relative;
+    }
+
+    .copy-icon {
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+  }
 }
 
 .app-frame {


### PR DESCRIPTION
Add copy button to raw version of content object version metadata.
Handle case for metadata diff where current version has no previous version.

https://user-images.githubusercontent.com/91760982/136614771-408b79d3-2b64-4f9a-902a-8f075501ab0d.mov

Button not shown on empty state
![Screen Shot 2021-10-08 at 12 12 45 PM](https://user-images.githubusercontent.com/91760982/136614849-e88be067-06ee-4f9e-bcc0-0a775f8ffd85.png)

- Diff button visible for latest version when versionCount > 0 and nth version except when current version is the last in versions array.
- Copy button uses Copyable component