### PR TITLE
Switch argument order for metadata diff

### DIFF
--- a/src/components/components/Diff.js
+++ b/src/components/components/Diff.js
@@ -11,7 +11,7 @@ const Diff = observer(({json, diff}) => {
   const RenderDiff = () => {
     typeof json.meta === "string" ? json.meta = JSON.parse(json.meta || "{}") : json.meta;
 
-    const diffArray = diffJson(json.meta, diff || objectStore.versions[previousVersionHash].meta);
+    const diffArray = diffJson(diff || objectStore.versions[previousVersionHash].meta, json.meta);
     const parts = diffArray.map((part, i) => {
       return <p key={i} className={part.added ? "part-addition" : part.removed ? "part-deletion" : ""}>{part.value}</p>;
     });


### PR DESCRIPTION
Current version metadata is being passed to diff library as old data and previous version is being passed as new data. 
- Switch the order of arguments in Diff.js

![image](https://user-images.githubusercontent.com/91760982/137558416-c021cc74-663e-4160-b7a6-434e5c93c8a2.png)
