### PR TITLE
Add ability to copy a content object

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "last 2 versions"
   ],
   "dependencies": {
-    "@eluvio/elv-client-js": "^3.1.66",
+    "@eluvio/elv-client-js": "^3.1.75",
     "bignumber.js": "^8.1.1",
     "browser-cancelable-events": "^1.0.1",
     "browser-solc": "^1.0.0",

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -952,6 +952,22 @@ const Fabric = {
     });
   },
 
+  CopyContentObject: async({
+    libraryId,
+    originalVersionHash,
+    options={},
+    originalObject=null
+  }) => {
+    const response = await client.CopyContentObject({
+      libraryId,
+      originalVersionHash,
+      options,
+      originalObject
+    });
+
+    return response;
+  },
+
   FinalizeContentObject: async ({
     libraryId,
     objectId,

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -955,14 +955,12 @@ const Fabric = {
   CopyContentObject: async({
     libraryId,
     originalVersionHash,
-    options={},
-    originalObject=null
+    options={}
   }) => {
     const response = await client.CopyContentObject({
       libraryId,
       originalVersionHash,
-      options,
-      originalObject
+      options
     });
 
     return response;

--- a/src/components/components/ContentBrowser.js
+++ b/src/components/components/ContentBrowser.js
@@ -13,15 +13,15 @@ const ContentLookup = ({Select}) => {
   };
 
   return (
-    <div className="actions-container content-browse-lookup">
+    <div className="actions-container content-browser-lookup">
       <input
-        className="action-input content-browse-lookup-input"
+        className="action-input content-browser-lookup-input"
         value={value}
         onChange={event => setValue(event.target.value)}
         onKeyDown={onEnterPressed(Lookup)}
         placeholder="Find content by ID, hash, or address"
       />
-      <button className="content-browse-lookup-button" onClick={Lookup}>
+      <button className="content-browser-lookup-button" onClick={Lookup}>
         <ImageIcon
           title="Find Content"
           icon={SearchIcon}

--- a/src/components/components/ContentBrowser.js
+++ b/src/components/components/ContentBrowser.js
@@ -1,0 +1,310 @@
+import React, {useEffect, useState} from "react";
+import {contentStore} from "../../stores";
+import {observer} from "mobx-react";
+
+import SearchIcon from "../../static/icons/search.svg";
+import {Modal, onEnterPressed, ImageIcon, AsyncComponent, Action} from "elv-components-js";
+
+const ContentLookup = ({Select}) => {
+  const [value, setValue] = useState("");
+  const Lookup = async () => {
+    Select(await contentStore.LookupContent(value));
+    setValue("");
+  };
+
+  return (
+    <div className="actions-container content-browse-lookup">
+      <input
+        className="action-input content-browse-lookup-input"
+        value={value}
+        onChange={event => setValue(event.target.value)}
+        onKeyDown={onEnterPressed(Lookup)}
+        placeholder="Find content by ID, hash, or address"
+      />
+      <button className="content-browse-lookup-button" onClick={Lookup}>
+        <ImageIcon
+          title="Find Content"
+          icon={SearchIcon}
+          className="content-browser-lookup-button-icon"
+        />
+      </button>
+    </div>
+  );
+};
+
+let pageTimeout, filterTimeout;
+const Controls = ({filter, setFilter, page, setPage, totalPages}) => {
+  const [ tempFilter, setTempFilter ] = useState(filter);
+  const [ tempPage, setTempPage ] = useState(page);
+
+  useEffect(() => {
+    setTempPage(page);
+    setTempFilter(filter);
+  }, [filter, page, totalPages]);
+
+  const UpdatePage = page => {
+    clearTimeout(pageTimeout);
+    setTempPage(page);
+    pageTimeout = setTimeout(() => {
+      setPage(page);
+    }, 300);
+  };
+
+  return (
+    <div className="actions-container content-browser-controls">
+      <input
+        value={tempFilter}
+        onChange={event => {
+          clearTimeout(filterTimeout);
+          setTempFilter(event.target.value);
+          filterTimeout = setTimeout(() => {
+            setPage(1);
+            setTempFilter(event.target.value);
+            setFilter(event.target.value);
+          }, 750);
+        }}
+        className="action-input content-browser-filter"
+        placeholder="Filter..."
+      />
+      <div className="content-browser-page-controls">
+        <button
+          className="content-browser-page-button"
+          disabled={page <= 1}
+          onClick={() => UpdatePage(tempPage - 1)}
+        >
+          { "<" }
+        </button>
+        <div className="content-browser-page">
+          { Math.min(tempPage, totalPages) } / { totalPages }
+        </div>
+        <button
+          className="content-browser-page-button"
+          disabled={page >= totalPages}
+          onClick={() => UpdatePage(tempPage + 1)}
+        >
+          { ">" }
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const VersionBrowser = observer(({libraryId, objectId, Select}) => {
+  const [filter, setFilter] = useState("");
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  const [versions, setVersions] = useState([]);
+
+  return (
+    <>
+      <Controls filter={filter} setFilter={setFilter} page={page} setPage={setPage} totalPages={totalPages} />
+      <AsyncComponent
+        key={`version-browser-${libraryId}-${objectId}`}
+        Load={async () => {
+          await contentStore.LoadLibraries();
+          const objectInfo = await contentStore.LoadObject({libraryId, objectId});
+
+          setVersions(objectInfo.versions);
+          setTotalPages(Math.ceil(objectInfo.versions.length / contentStore.OBJECTS_PER_PAGE));
+        }}
+      >
+        <div className="list content-list content-list-versions">
+          {
+            (versions || [])
+              .filter(versionHash => !filter || versionHash.includes(filter))
+              .slice((page - 1) * contentStore.OBJECTS_PER_PAGE, page * contentStore.OBJECTS_PER_PAGE)
+              .map(versionHash =>
+                <button onClick={() => Select(versionHash)} className="list-item content-list-item" key={`version-${versionHash}`}>
+                  { versionHash }
+                </button>
+              )
+          }
+        </div>
+      </AsyncComponent>
+    </>
+  );
+});
+
+const ObjectBrowser = observer(({libraryId, Select}) => {
+  const [filter, setFilter] = useState("");
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  const [objects, setObjects] = useState([]);
+
+  return (
+    <>
+      <Controls filter={filter} setFilter={setFilter} page={page} setPage={setPage} totalPages={totalPages} />
+      <AsyncComponent
+        key={`object-browser-${libraryId}-${page}-${filter}`}
+        Load={async () => {
+          await contentStore.LoadLibraries();
+          const { objects, paging } = await contentStore.LoadObjects({libraryId, filter, page});
+
+          setPage(page);
+          setTotalPages(paging.pages);
+          setObjects(objects);
+        }}
+      >
+        <div className="list content-list content-list-objects">
+          {
+            (objects || [])
+              .map(({objectId, versionHash, name, playable, title}) =>
+                <button title={title} onClick={() => Select({name, playable, objectId, versionHash})} className="list-item content-list-item" key={`object-${objectId}`}>
+                  { name }
+                </button>
+              )
+          }
+        </div>
+      </AsyncComponent>
+    </>
+  );
+});
+
+const LibraryBrowser = observer(({Select}) => {
+  const [filter, setFilter] = useState("");
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  return (
+    <>
+      <Controls filter={filter} setFilter={setFilter} page={page} setPage={setPage} totalPages={totalPages} />
+      <AsyncComponent
+        Load={async () => {
+          await contentStore.LoadLibraries();
+          setPage(1);
+          setTotalPages(Math.ceil(Object.keys(contentStore.libraries).length / contentStore.OBJECTS_PER_PAGE));
+        }}
+      >
+        <div className="list content-list content-list-libraries">
+          {
+            Object.values(contentStore.libraries || {})
+              .filter(({name}) => !filter || (name || "").toLowerCase().includes(filter))
+              .sort((a, b) => (a.name || "").toLowerCase() < (b.name || "").toLowerCase() ? -1 : 1)
+              .slice((page - 1) * contentStore.OBJECTS_PER_PAGE, page * contentStore.OBJECTS_PER_PAGE)
+              .map(({libraryId, name}) =>
+                <button onClick={() => Select(libraryId)} className="list-item content-list-item" key={`library-${libraryId}`}>
+                  { name }
+                </button>
+              )
+          }
+        </div>
+      </AsyncComponent>
+    </>
+  );
+});
+
+const ContentBrowser = observer(({header, Select, Close, requireVersion=false, requireObject=true}) => {
+  const [libraryId, setLibraryId] = useState("");
+  const [objectId, setObjectId] = useState("");
+  const [objectName, setObjectName] = useState("");
+  const [objectPlayable, setObjectPlayable] = useState(false);
+
+  const FinalSelect = args => {
+    Select(args);
+    Close();
+  };
+  return (
+    <div className="content-browser">
+      <div className="content-browser-header-actions">
+        <ContentLookup
+          Select={({name, playable, libraryId, objectId, versionHash, latestVersionHash}) => {
+            if(versionHash) {
+              FinalSelect({name, libraryId, objectId, versionHash});
+            } else if(objectId && !requireVersion) {
+              FinalSelect({name, libraryId, objectId, versionHash: latestVersionHash});
+            } else if(objectId) {
+              setLibraryId(libraryId);
+              setObjectId(objectId);
+            } else if(libraryId) {
+              setLibraryId(libraryId);
+            }
+
+            setObjectName(name);
+            setObjectPlayable(playable);
+          }}
+        />
+        {
+          Close ?
+            <div className="actions-container">
+              <Action type="button" className="secondary" onClick={Close}>Cancel</Action>
+            </div> : null
+        }
+      </div>
+      <div className="content-browser-header">
+        <h1 className="content-header">
+          { header || "Select an Object" }
+        </h1>
+      </div>
+      <div className="content-browser-navigation">
+        {
+          libraryId ?
+            <a className="content-browser-back-button" onClick={() => {
+              if(objectId) {
+                setObjectId(undefined);
+                setObjectName("");
+                setObjectPlayable(false);
+              } else {
+                setLibraryId(undefined);
+              }
+            }
+            }>
+              Back to {objectId ? "Content Objects" : "Libraries"}
+            </a> : null
+        }
+        <h2 className="content-browser-location">
+          { !libraryId ? "Content Libraries" : (objectName || (contentStore.libraries[libraryId] || {}).name) }
+        </h2>
+      </div>
+      { !libraryId ?
+        <LibraryBrowser
+          Select={libraryId => {
+            setLibraryId(libraryId);
+
+            if(!requireObject) {
+              FinalSelect({libraryId});
+            }
+          }}
+        /> : null
+      }
+      { libraryId && !objectId ?
+        <ObjectBrowser
+          libraryId={libraryId}
+          Select={({name, playable, objectId, versionHash}) => {
+            if(requireVersion) {
+              setObjectName(name);
+              setObjectPlayable(name);
+              setObjectId(objectId);
+            } else {
+              FinalSelect({
+                name,
+                playable,
+                libraryId,
+                objectId,
+                versionHash
+              });
+            }
+          }}
+        /> : null
+      }
+      { libraryId && objectId ?
+        <VersionBrowser
+          libraryId={libraryId}
+          objectId={objectId}
+          Select={versionHash => FinalSelect({name: objectName, playable: objectPlayable, libraryId, objectId, versionHash})}
+        /> : null
+      }
+    </div>
+  );
+});
+
+export const ContentBrowserModal = (args) => {
+  return (
+    <Modal className="content-browser-modal" Close={args.Close}>
+      <ContentBrowser {...args} />
+    </Modal>
+  );
+};
+
+export default ContentBrowser;

--- a/src/components/components/ContentBrowser.js
+++ b/src/components/components/ContentBrowser.js
@@ -209,7 +209,7 @@ const ContentBrowser = observer(({header, Select, Close, requireVersion=false, r
     Close();
   };
   return (
-    <div className="content-browser">
+    <div className={`content-browser ${loading ? "copy-loading" : ""}`}>
       <LoadingElement loading={loading}>
         <div className="content-browser-header-actions">
           <ContentLookup

--- a/src/components/components/ContentBrowser.js
+++ b/src/components/components/ContentBrowser.js
@@ -213,7 +213,6 @@ const ContentBrowser = observer(({header, Select, Close, requireVersion=false, r
         await Select(args);
       }
     });
-    setLoading(false);
     Close();
   };
 

--- a/src/components/components/ContentBrowser.js
+++ b/src/components/components/ContentBrowser.js
@@ -300,6 +300,10 @@ const ContentBrowser = observer(({header, Select, Close, requireVersion=false, r
           /> : null
         }
       </LoadingElement>
+      {
+        loading ?
+          <div className="copying-text">Copying object</div> : null
+      }
     </div>
   );
 });

--- a/src/components/components/ContentBrowser.js
+++ b/src/components/components/ContentBrowser.js
@@ -211,9 +211,17 @@ const ContentBrowser = observer(({header, Select, Close, requireVersion=false, r
       message: `Are you sure you want to copy ${args.name} into ${args.libraryName}?`,
       onConfirm: async () => {
         await Select(args);
+        Close();
+      },
+      onCancel: () => {
+        setLibraryId(undefined);
+        setLibraryName(undefined);
+        setObjectId(undefined);
+        setObjectName("");
+        setObjectPlayable(false);
+        setLoading(false);
       }
     });
-    Close();
   };
 
   return (

--- a/src/components/components/ToggleSection.js
+++ b/src/components/components/ToggleSection.js
@@ -2,7 +2,7 @@ import React, {useEffect, useRef, useState} from "react";
 import {LabelledField} from "./LabelledField";
 import {Action} from "elv-components-js";
 
-const ToggleSection = React.forwardRef(({label, children, className="", toggleOpen=false}) => {
+const ToggleSection = ({label, children, className="", toggleOpen=false}) => {
   const [show, setShow] = useState(toggleOpen);
   const ref = useRef(null);
 
@@ -24,6 +24,6 @@ const ToggleSection = React.forwardRef(({label, children, className="", toggleOp
       </div>
     </div>
   );
-});
+};
 
 export default ToggleSection;

--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -385,8 +385,7 @@ class ContentLibrary extends React.Component {
             name: `${originalObject.name} (copy)`
           }
         }
-      },
-      originalObject: originalObject
+      }
     });
   }
 

--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -17,6 +17,7 @@ import JSONField from "../../components/JSONField";
 import ContentLibraryGroupForm from "./ContentLibraryGroupForm";
 import ContentLookup from "../../components/ContentLookup";
 import {ContentBrowserModal} from "../../components/ContentBrowser";
+import {Redirect} from "react-router";
 
 @inject("libraryStore")
 @inject("groupStore")
@@ -33,7 +34,7 @@ class ContentLibrary extends React.Component {
       pageVersion: 0,
       showGroupForm: false,
       listingVersion: 0,
-      objectListingVersion: 0
+      objectId: ""
     };
 
     this.PageContent = this.PageContent.bind(this);
@@ -377,7 +378,7 @@ class ContentLibrary extends React.Component {
   CopyObject = async (object) => {
     const originalObject = object.name ? object : this.props.objectStore.object;
 
-    await this.props.objectStore.CopyContentObject({
+    const {id} = await this.props.objectStore.CopyContentObject({
       libraryId: object.libraryId,
       originalVersionHash: originalObject.versionHash || originalObject.hash,
       options: {
@@ -388,6 +389,8 @@ class ContentLibrary extends React.Component {
         }
       }
     });
+
+    this.setState({objectId: id});
   }
 
   PageContent() {
@@ -402,6 +405,12 @@ class ContentLibrary extends React.Component {
         onChange={(value) => this.setState({view: value})}
       />
     );
+
+    if(this.state.objectId) {
+      const redirectPath = UrlJoin(this.props.match.url, this.state.objectId);
+
+      return <Redirect push to={redirectPath} />;
+    }
 
     return (
       <div className="page-container contents-page-container">
@@ -419,7 +428,7 @@ class ContentLibrary extends React.Component {
         {
           this.state.showCopyObjectModal ?
             <ContentBrowserModal
-              Close={() =>  this.setState({showCopyObjectModal: false, objectListingVersion: this.state.objectListingVersion + 1})}
+              Close={() =>  this.setState({showCopyObjectModal: false})}
               Select={selection => this.CopyObject(selection)}
             /> : null
         }

--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -32,7 +32,8 @@ class ContentLibrary extends React.Component {
       version: 0,
       pageVersion: 0,
       showGroupForm: false,
-      listingVersion: 0
+      listingVersion: 0,
+      objectListingVersion: 0
     };
 
     this.PageContent = this.PageContent.bind(this);
@@ -179,7 +180,7 @@ class ContentLibrary extends React.Component {
   ObjectListing() {
     return (
       <Listing
-        key="library-objects-view"
+        key={`library-objects-view-${this.state.objectListingVersion}`}
         pageId="ContentObjects"
         paginate={true}
         page={this.props.libraryStore.library.listingParams.page}
@@ -417,7 +418,10 @@ class ContentLibrary extends React.Component {
         </div>
         {
           this.state.showCopyObjectModal ?
-            <ContentBrowserModal Close={() =>  this.setState({showCopyObjectModal: false})} Select={(selection) => this.CopyObject(selection)}/> : null
+            <ContentBrowserModal
+              Close={() =>  this.setState({showCopyObjectModal: false, objectListingVersion: this.state.objectListingVersion + 1})}
+              Select={selection => this.CopyObject(selection)}
+            /> : null
         }
       </div>
     );

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -87,6 +87,20 @@ class ContentObject extends React.Component {
     this.UpdateMetadata = this.UpdateMetadata.bind(this);
   }
 
+  async componentDidMount() {
+    this.mounted = true;
+
+    // Wait a bit to avoid react mount-unmount bounce
+    await new Promise(resolve => setTimeout(resolve, 50));
+    if(!this.mounted) {
+      return;
+    }
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
   async SubmitContentObject(confirmationMessage) {
     await Confirm({
       message: confirmationMessage,
@@ -907,7 +921,11 @@ class ContentObject extends React.Component {
         {
           this.state.showCopyObjectModal ?
             <ContentBrowserModal
-              Close={() =>  this.setState({showCopyObjectModal: false})}
+              Close={() => {
+                if(this.mounted) {
+                  this.setState({showCopyObjectModal: false});
+                }
+              }}
               Select={(selection) => this.CopyObject(selection)}
               requireObject={false}
               header="Select a library"

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -77,10 +77,10 @@ class ContentObject extends React.Component {
       currentVersionToggled: false,
       prevVersionsToggled: false,
       moreOptions: false,
-      showCopyObjectModal: false
+      showCopyObjectModal: false,
+      redirectIds: {}
     };
 
-    this.toggleRef = React.createRef();
     this.PageContent = this.PageContent.bind(this);
     this.SubmitContentObject = this.SubmitContentObject.bind(this);
     this.FinalizeABRMezzanine = this.FinalizeABRMezzanine.bind(this);
@@ -791,7 +791,7 @@ class ContentObject extends React.Component {
   CopyObject = async (object) => {
     const originalObject = object.name ? object : this.props.objectStore.object;
 
-    await this.props.objectStore.CopyContentObject({
+    const {id, qlib_id} = await this.props.objectStore.CopyContentObject({
       libraryId: object.libraryId,
       originalVersionHash: originalObject.versionHash || originalObject.hash,
       options: {
@@ -802,11 +802,22 @@ class ContentObject extends React.Component {
         }
       }
     });
+
+    this.setState({
+      redirectIds: {
+        objectId: id,
+        libraryId: qlib_id
+      }
+    });
   }
 
   PageContent() {
     if(this.state.deleted) {
       return <Redirect push to={Path.dirname(this.props.match.url)} />;
+    }
+
+    if(this.state.redirectIds.objectId && this.state.redirectIds.libraryId) {
+      return <Redirect to={`/content/${this.state.redirectIds.libraryId}/${this.state.redirectIds.objectId}`} />;
     }
 
     let header;

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -23,6 +23,7 @@ import RefreshIcon from "../../../static/icons/refresh.svg";
 import InfoIcon from "../../../static/icons/help-circle.svg";
 import Diff from "../../components/Diff";
 import ContentLookup from "../../components/ContentLookup";
+import {ContentBrowserModal} from "../../components/ContentBrowser";
 
 const DownloadPart = ({libraryId, objectId, versionHash, partHash, partName, DownloadMethod}) => {
   const [progress, setProgress] = useState(undefined);
@@ -75,7 +76,8 @@ class ContentObject extends React.Component {
       loadingVersions: false,
       currentVersionToggled: false,
       prevVersionsToggled: false,
-      moreOptions: false
+      moreOptions: false,
+      showCopyObjectModal: false
     };
 
     this.toggleRef = React.createRef();
@@ -712,6 +714,12 @@ class ContentObject extends React.Component {
       );
     }
 
+    const copyObjectButton = (
+      <Action className="primary" onClick={() => this.setState({showCopyObjectModal: true})}>
+        Copy
+      </Action>
+    );
+
     return (
       <div className="actions-wrapper">
         <div className="actions-container">
@@ -727,6 +735,7 @@ class ContentObject extends React.Component {
           <Action type="link" to={UrlJoin(this.props.match.url, "apps")}>
             Apps
           </Action>
+          { copyObjectButton }
           { deleteObjectButton }
           { saveDraftButton }
           { refreshButton }
@@ -777,6 +786,23 @@ class ContentObject extends React.Component {
         onChange={(value) => this.setState({view: value})}
       />
     );
+  }
+
+  CopyObject = async (object) => {
+    const originalObject = object.name ? object : this.props.objectStore.object;
+
+    await this.props.objectStore.CopyContentObject({
+      libraryId: object.libraryId,
+      originalVersionHash: originalObject.versionHash || originalObject.hash,
+      options: {
+        meta: {
+          public: {
+            name: `${originalObject.name} (copy)`
+          }
+        }
+      },
+      originalObject: originalObject
+    });
   }
 
   PageContent() {
@@ -868,6 +894,15 @@ class ContentObject extends React.Component {
             { pageContent }
           </div>
         </div>
+        {
+          this.state.showCopyObjectModal ?
+            <ContentBrowserModal
+              Close={() =>  this.setState({showCopyObjectModal: false})}
+              Select={(selection) => this.CopyObject(selection)}
+              requireObject={false}
+              header="Select a library"
+            /> : null
+        }
       </div>
     );
   }

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -800,8 +800,7 @@ class ContentObject extends React.Component {
             name: `${originalObject.name} (copy)`
           }
         }
-      },
-      originalObject: originalObject
+      }
     });
   }
 

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -789,7 +789,7 @@ class ContentObject extends React.Component {
   }
 
   CopyObject = async (object) => {
-    const originalObject = object.name ? object : this.props.objectStore.object;
+    const originalObject = object.versionHash ? object : this.props.objectStore.object;
 
     const {id, qlib_id} = await this.props.objectStore.CopyContentObject({
       libraryId: object.libraryId,

--- a/src/components/pages/content/ContentObjectForm.js
+++ b/src/components/pages/content/ContentObjectForm.js
@@ -207,7 +207,7 @@ class ContentObjectForm extends React.Component {
   }
 
   PageContent() {
-    const legend = this.state.createForm ? "Contribute content" : `Manage ${this.state.name || "content"}`;
+    const legend = this.state.createForm ? "Create content" : `Manage ${this.state.name || "content"}`;
 
     let redirectPath = Path.dirname(this.props.match.url);
     if(this.state.createForm) {

--- a/src/static/icons/search.svg
+++ b/src/static/icons/search.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-search"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>

--- a/src/static/stylesheets/app.scss
+++ b/src/static/stylesheets/app.scss
@@ -12,6 +12,4 @@
 @import "file_browser";
 @import "listing";
 @import "forms";
-
-
-
+@import "content_browser";

--- a/src/static/stylesheets/content_browser.scss
+++ b/src/static/stylesheets/content_browser.scss
@@ -201,4 +201,10 @@
       }
     }
   }
+
+  .copying-text {
+    display: flex;
+    justify-content: center;
+    margin-top: $elv-spacing-s;
+  }
 }

--- a/src/static/stylesheets/content_browser.scss
+++ b/src/static/stylesheets/content_browser.scss
@@ -201,13 +201,4 @@
       }
     }
   }
-
-  &.copy-loading {
-    justify-content: center;
-    align-items: center;
-  }
-
-  .copying-text {
-    margin-top: $elv-spacing-s;
-  }
 }

--- a/src/static/stylesheets/content_browser.scss
+++ b/src/static/stylesheets/content_browser.scss
@@ -1,0 +1,204 @@
+// sass-lint:disable function-name-format
+
+.-elv-modal {
+  &.content-browser-modal {
+    .-elv-modal-content {
+      max-width: MIN(90vw, 1000px);
+      width: 100%;
+    }
+  }
+}
+
+.content-browser-modal {
+  width: 100%;
+
+  .content-browser {
+    height: 100vh;
+    max-width: 1000px;
+    padding: 20px 40px 40px;
+    width: MIN(100vw, 100%);
+  }
+}
+
+.content-browser {
+  display: flex;
+  flex: 1 1 100%;
+  flex-direction: column;
+  height: 100%;
+  max-height: 100%;
+  min-height: 500px;
+  width: 100%;
+
+  &-header {
+    align-items: center;
+    display: flex;
+    margin: 15px 0;
+
+    h1 {
+      font-size: 24px;
+      font-weight: 300;
+      text-align: center;
+      width: 100%;
+    }
+  }
+
+  &-header-actions {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+
+    .actions-container {
+      width: auto;
+    }
+  }
+
+  .content-list {
+    display: flex;
+    flex-direction: column;
+    max-height: 100%;
+    overflow-y: scroll;
+    width: 100%;
+
+    .list-item {
+      background-color: unset;
+      border-bottom: 0;
+      border-left: 3px solid transparent;
+      border-right: 0;
+      border-top: 0;
+      cursor: pointer;
+      min-height: 50px;
+      padding: 15px 20px;
+
+      &:not(.list-header):not(:disabled):hover { // sass-lint:disable-line force-pseudo-nesting
+        border-left: 3px solid $elv-color-mediumblue;
+      }
+    }
+
+    &-item {
+
+      &:nth-child(odd) {
+        background-color: $elv-color-lightestgray;
+      }
+    }
+
+    &-versions {
+      .content-list-item {
+        @include elv-ellipsis;
+        font-size: 14px;
+      }
+    }
+  }
+
+  &-lookup {
+    display: flex;
+    height: 35px;
+    min-width: 300px;
+    padding: 0;
+    width: 300px;
+  }
+
+  &-lookup-input {
+    border: 1px solid $elv-color-mediumgray;
+    font-size: 12px;
+    height: 100%;
+    text-align: left;
+    width: 100%;
+
+    &::placeholder {
+      padding: 0;
+    }
+  }
+
+  &-lookup-button {
+    border: 1px solid $elv-color-mediumgray;
+    border-radius: 3px;
+    cursor: pointer;
+    height: 100%;
+    margin-left: 5px;
+    min-width: 35px;
+    padding: 8px;
+    width: 35px;
+
+    .content-browser-lookup-button-icon {
+      height: 100%;
+      width: 100%;
+    }
+  }
+
+
+  &-navigation {
+    align-items: center;
+    display: flex;
+    height: 50px;
+    justify-content: center;
+    min-height: 50px;
+    position: relative;
+    width: 100%;
+  }
+
+  &-location {
+    @include elv-ellipsis;
+
+    font-size: 20px;
+    font-weight: 300;
+    text-align: center;
+    width: 100%;
+  }
+
+  &-back-button {
+    color: $elv-color-mediumblue;
+    cursor: pointer;
+    left: 0;
+    min-width: 190px;
+    position: absolute;
+    text-decoration: underline;
+  }
+
+  &-page-controls {
+    align-items: center;
+    display: flex;
+    flex: 1 1 100%;
+    height: 100%;
+    justify-content: flex-end;
+  }
+
+  &-page {
+    color: $elv-color-darkgray;
+    font-size: 20px;
+    font-weight: 300;
+    margin: 0 20px;
+    text-align: center;
+    width: 90px;
+  }
+
+  &-page-button {
+    border: 1px solid $elv-color-mediumgray;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    height: 100%;
+    text-align: center;
+    user-select: none;
+    width: 40px;
+
+    &:disabled {
+      cursor: auto;
+      opacity: 0.25;
+    }
+  }
+
+  .actions-container {
+    &.content-browser-controls {
+      align-items: center;
+      display: flex;
+      padding: 20px 0;
+      width: 100%;
+
+      .action-input {
+        max-width: 400px;
+        width: 100%;
+      }
+    }
+  }
+}

--- a/src/static/stylesheets/content_browser.scss
+++ b/src/static/stylesheets/content_browser.scss
@@ -13,7 +13,7 @@
   width: 100%;
 
   .content-browser {
-    height: 100vh;
+    height: calc(100vh - 100px);
     max-width: 1000px;
     padding: 20px 40px 40px;
     width: MIN(100vw, 100%);
@@ -202,9 +202,12 @@
     }
   }
 
-  .copying-text {
-    display: flex;
+  &.copy-loading {
     justify-content: center;
+    align-items: center;
+  }
+
+  .copying-text {
     margin-top: $elv-spacing-s;
   }
 }

--- a/src/stores/Content.js
+++ b/src/stores/Content.js
@@ -6,49 +6,14 @@ class ContentStore {
 
   @observable libraries = undefined;
   contentTypesPromise = undefined;
-  tenantObjectId = undefined;
-  tenant = undefined;
 
   @computed get client() {
     return this.rootStore.client;
   }
 
-  @computed get events() {
-    return Object.keys(Utils.SafeTraverse(this.tenant, "sites") || {}).map(eventSlug => {
-      const event = this.tenant.sites[eventSlug];
-
-      if(!event || !event["."]) {
-        return;
-      }
-
-      return {
-        objectId: Utils.DecodeVersionHash(event["."].source).objectId,
-        versionHash: event["."].source,
-        slug: eventSlug,
-        name: event.display_title
-      };
-    }).filter(event => event);
-  }
-
   constructor(rootStore) {
-    // makeAutoObservable(this,
-    //   {
-    //     client: computed,
-    //     events: computed
-    //   }
-    // );
-
     this.rootStore = rootStore;
   }
-
-  Initialize = flow(function * () {
-    // Loading content types takes a while, so start it immediately
-    this.contentTypesPromise = this.client.ContentTypes();
-
-    this.tenantObjectId = yield this.LiveTenantObjectId();
-
-    yield this.LoadTenant();
-  });
 
   LoadLibraries = flow(function * () {
     if(!this.libraries) {

--- a/src/stores/Content.js
+++ b/src/stores/Content.js
@@ -1,0 +1,197 @@
+import {flow, computed, observable} from "mobx";
+import Utils from "@eluvio/elv-client-js/src/Utils";
+
+class ContentStore {
+  OBJECTS_PER_PAGE = 50;
+
+  @observable libraries = undefined;
+  contentTypesPromise = undefined;
+  tenantObjectId = undefined;
+  tenant = undefined;
+
+  @computed get client() {
+    return this.rootStore.client;
+  }
+
+  @computed get events() {
+    return Object.keys(Utils.SafeTraverse(this.tenant, "sites") || {}).map(eventSlug => {
+      const event = this.tenant.sites[eventSlug];
+
+      if(!event || !event["."]) {
+        return;
+      }
+
+      return {
+        objectId: Utils.DecodeVersionHash(event["."].source).objectId,
+        versionHash: event["."].source,
+        slug: eventSlug,
+        name: event.display_title
+      };
+    }).filter(event => event);
+  }
+
+  constructor(rootStore) {
+    // makeAutoObservable(this,
+    //   {
+    //     client: computed,
+    //     events: computed
+    //   }
+    // );
+
+    this.rootStore = rootStore;
+  }
+
+  Initialize = flow(function * () {
+    // Loading content types takes a while, so start it immediately
+    this.contentTypesPromise = this.client.ContentTypes();
+
+    this.tenantObjectId = yield this.LiveTenantObjectId();
+
+    yield this.LoadTenant();
+  });
+
+  LoadLibraries = flow(function * () {
+    if(!this.libraries) {
+      this.libraries = {};
+
+      const libraryIds = yield this.client.ContentLibraries();
+      yield Promise.all(
+        libraryIds.map(async libraryId => {
+          const name = (await this.client.ContentObjectMetadata({
+            libraryId,
+            objectId: libraryId.replace(/^ilib/, "iq__"),
+            metadataSubtree: "public/name"
+          })) || libraryId;
+
+          this.libraries[libraryId] = {
+            libraryId,
+            name
+          };
+        })
+      );
+    }
+
+    return this.libraries;
+  });
+
+  LoadObjects = flow(function * ({libraryId, page=1, filter, sortKey="/public/name", sortAsc=true}) {
+    const { contents, paging } = yield this.client.ContentObjects({
+      libraryId,
+      filterOptions: {
+        select: [
+          "public/name",
+          "public/asset_metadata/title",
+          "public/asset_metadata/display_title",
+          "public/asset_metadata/sources"
+        ],
+        sort: sortKey,
+        start: (page - 1) * this.OBJECTS_PER_PAGE,
+        limit: this.OBJECTS_PER_PAGE,
+        sortDesc: !sortAsc,
+        filter: !filter ? null :
+          {
+            key: "/public/name",
+            type: "cnt",
+            filter: filter.toLowerCase()
+          }
+      }
+    });
+
+    const objects = contents.map(({id, versions}) => {
+      const versionHash = versions[0].hash;
+      const metadata = (versions[0].meta || {});
+      const assetMetadata = ((metadata || {}).public || {}).asset_metadata || {};
+
+      return {
+        objectId: id,
+        versionHash,
+        name: (metadata.public || {}).name || id,
+        playable: !!assetMetadata.sources,
+        title: assetMetadata.display_title || assetMetadata.title
+      };
+    });
+
+    return { objects, paging };
+  });
+
+  LoadObject = flow(function * ({libraryId, objectId}) {
+    const [objectInfo, versions] = yield Promise.all([
+      this.client.ContentObject({
+        libraryId,
+        objectId
+      }),
+      this.client.ContentObjectVersions({
+        libraryId,
+        objectId
+      })
+    ]);
+
+    const types = yield this.contentTypesPromise;
+
+    return {
+      type: objectInfo.type ? types[Utils.DecodeVersionHash(objectInfo.type).objectId] : null,
+      versions: versions.versions.map(version => version.hash)
+    };
+  });
+
+  async LookupContent(contentId) {
+    contentId = contentId.replace(/ /g, "");
+
+    if(!contentId) { return; }
+
+    try {
+      let libraryId, objectId, versionHash, latestVersionHash, name, accessType;
+      if(contentId.startsWith("ilib")) {
+        libraryId = contentId;
+        accessType = "library";
+      } else if(contentId.startsWith("hq__")) {
+        versionHash = contentId;
+        objectId = Utils.DecodeVersionHash(contentId).objectId;
+      } else if(contentId.startsWith("iq__")) {
+        objectId = contentId;
+        latestVersionHash = await this.client.LatestVersionHash({objectId});
+      } else if(contentId.startsWith("0x")) {
+        const id = Utils.AddressToObjectId(contentId);
+        accessType = await this.client.AccessType({id});
+
+        if(accessType === "library") {
+          libraryId = Utils.AddressToLibraryId(contentId);
+        } else {
+          objectId = id;
+        }
+      } else {
+        objectId = Utils.AddressToObjectId(Utils.HashToAddress(contentId));
+      }
+
+      if(objectId && !libraryId) {
+        libraryId = await this.client.ContentObjectLibraryId({objectId});
+      }
+
+      if(!accessType) {
+        accessType = await this.client.AccessType({id: objectId});
+      }
+
+      if(objectId) {
+        name = await this.client.ContentObjectMetadata({
+          versionHash: versionHash || latestVersionHash,
+          metadataSubtree: "public/name"
+        });
+      }
+
+      if(accessType === "library") {
+        return { libraryId };
+      } else if(accessType === "object") {
+        return { name, libraryId, objectId, versionHash, latestVersionHash };
+      }
+
+      throw Error(`Unsupported type '${accessType}'`);
+    } catch(error) {
+      // eslint-disable-next-line no-console
+      console.error("Failed to look up ID:", error);
+
+      return {};
+    }
+  }
+}
+
+export default ContentStore;

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -216,7 +216,7 @@ class ObjectStore {
     return this.writeTokens[objectId];
   });
 
-  @action.bound CopyContentObject = flow(function * ({libraryId, originalVersionHash, options={}, originalObject=null}) {
+  @action.bound CopyContentObject = flow(function * ({libraryId, originalVersionHash, options={}}) {
     const response = yield Fabric.CopyContentObject({libraryId, originalVersionHash, options, originalObject});
 
     this.rootStore.notificationStore.SetNotificationMessage({

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -216,6 +216,17 @@ class ObjectStore {
     return this.writeTokens[objectId];
   });
 
+  @action.bound CopyContentObject = flow(function * ({libraryId, originalVersionHash, options={}, originalObject=null}) {
+    const response = yield Fabric.CopyContentObject({libraryId, originalVersionHash, options, originalObject});
+
+    this.rootStore.notificationStore.SetNotificationMessage({
+      message: "Successfully copied object",
+      redirect: true
+    });
+
+    return response;
+  });
+
   @action.bound
   FinalizeContentObject = flow(function * ({libraryId, objectId}) {
     const object = this.objects[objectId];
@@ -612,7 +623,7 @@ class ObjectStore {
   });
 
   @action.bound
-  RevewContentObject = flow(function * ({libraryId, objectId, approve, note}) {
+  ReviewContentObject = flow(function * ({libraryId, objectId, approve, note}) {
     yield Fabric.ReviewContentObject({libraryId, objectId, approve, note});
 
     const currentAccountAddress = yield Fabric.CurrentAccountAddress();

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -217,7 +217,7 @@ class ObjectStore {
   });
 
   @action.bound CopyContentObject = flow(function * ({libraryId, originalVersionHash, options={}}) {
-    const response = yield Fabric.CopyContentObject({libraryId, originalVersionHash, options, originalObject});
+    const response = yield Fabric.CopyContentObject({libraryId, originalVersionHash, options});
 
     this.rootStore.notificationStore.SetNotificationMessage({
       message: "Successfully copied object",

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -9,6 +9,7 @@ import GroupsStore from "./Group";
 import TypeStore from "./Type";
 import ObjectStore from "./Object";
 import NotificationStore from "./Notifications";
+import ContentStore from "./Content";
 
 // Force strict mode so mutations are only allowed within actions.
 configure({
@@ -30,6 +31,7 @@ class RootStore {
     this.objectStore = new ObjectStore(this);
     this.routerStore = new RouterStore(this);
     this.typeStore = new TypeStore(this);
+    this.contentStore = new ContentStore(this);
   }
 
   @action.bound
@@ -54,3 +56,4 @@ export const notificationStore = rootStore.notificationStore;
 export const objectStore = rootStore.objectStore;
 export const routeStore = rootStore.routerStore;
 export const typeStore = rootStore.typeStore;
+export const contentStore = rootStore.contentStore;


### PR DESCRIPTION
Allow user to copy a content object. See associated client-js PR: https://github.com/eluv-io/elv-client-js/pull/128.
The content browser modal is identical to the one used by live-manager.

Main test cases:
- Copying an object with no encryption keys
- Copying an object with kms and user caps keys
- Copying an object with one or the other ^
- File download flow for the owner of a copied object
- File download flow for the non-owner (member of an admin group) of a copied object
- Encrypted video files successfully download and play


![image](https://user-images.githubusercontent.com/91760982/140816724-63289d56-3160-4d82-ba8e-8390724730c3.png)



https://user-images.githubusercontent.com/91760982/141022944-f78c82f0-ac70-4639-bdb7-8e8b7ffb2b39.mov


https://user-images.githubusercontent.com/91760982/141022953-f1bc7718-340a-4943-9561-c5364251ce72.mov



Relates to #8 

Future improvements:
- Update sass-lint (disable-next-line is in latest update)
- Update mobx and mobx-react (for the use of makeAutoObservable and makeObservable). Updating these packages broke other pages so I think this should be a separate change to fix any code that needs to be updated.