### PR TITLE
Create owner cap management

### DIFF
--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -1182,12 +1182,18 @@ const Fabric = {
       writeToken
     });
 
+    const metadata = await Fabric.GetContentObjectMetadata({
+      libraryId,
+      objectId,
+      metadataSubtree: "/owner_caps"
+    });
+
     await client.ReplaceMetadata({
       libraryId,
       objectId,
       writeToken,
       metadataSubtree: "/owner_caps",
-      metadata: {[publicAddress]: name}
+      metadata: Object.assign(metadata, {[publicAddress]: name})
     });
 
     return await client.FinalizeContentObject({

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -1171,6 +1171,15 @@ const Fabric = {
     };
   },
 
+  CreateOwnerCap: async ({libraryId, objectId, publicKey, publicAddress}) => {
+    return await client.CreateOwnerCap({
+      libraryId,
+      objectId,
+      publicKey,
+      publicAddress: Fabric.utils.FormatAddress(publicAddress)
+    });
+  },
+
   /* Contract calls */
 
   GetContentLibraryPermissions: async ({libraryId}) => {

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -1171,12 +1171,30 @@ const Fabric = {
     };
   },
 
-  CreateOwnerCap: async ({libraryId, objectId, publicKey, publicAddress}) => {
-    return await client.CreateOwnerCap({
+  CreateNonOwnerCap: async ({libraryId, objectId, publicKey, publicAddress, name}) => {
+    const {writeToken} = await Fabric.EditContentObject({libraryId, objectId});
+
+    await client.CreateNonOwnerCap({
       libraryId,
       objectId,
       publicKey,
-      publicAddress: Fabric.utils.FormatAddress(publicAddress)
+      publicAddress: Fabric.utils.FormatAddress(publicAddress),
+      writeToken
+    });
+
+    await client.ReplaceMetadata({
+      libraryId,
+      objectId,
+      writeToken,
+      metadataSubtree: "/owner_caps",
+      metadata: {[publicAddress]: name}
+    });
+
+    return await client.FinalizeContentObject({
+      libraryId,
+      objectId,
+      writeToken,
+      commitMessage: "Create non-owner cap"
     });
   },
 

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -649,7 +649,7 @@ class ContentObject extends React.Component {
             className="secondary"
             onClick={() => this.setState({showNonOwnerCapManagement: true})}
           >
-            Add encryption key
+            Add Encryption Key
           </Action>
         </LabelledField>
       );
@@ -661,12 +661,13 @@ class ContentObject extends React.Component {
       <div className="non-owner-caps-container">
         <ToggleSection label="Encryption Keys" toggleOpen={this.state.showNonOwnerCapManagement}>
           {addCapsButton}
+          <br />
           {
-            encryptionObjectKeys.length > 0 ? <div className="keys-table">
+            encryptionObjectKeys.length > 0 ? <div className="keys-table indented">
               <div className="header-rows">
                 <div>Name</div>
                 <div>Address</div>
-                <div>Delete</div>
+                <div></div>
               </div>
               <div className="body-rows">
                 {encryptionObjectKeys.map(capAddress => (

--- a/src/static/stylesheets/content.scss
+++ b/src/static/stylesheets/content.scss
@@ -230,8 +230,11 @@ pre,
 
 .keys-table {
   max-width: 700px;
+  padding-left: 150px;
 
   .header-rows {
+    background-color: $elv-color-lightgray;
+    font-weight: 500;
     padding-bottom: 10px;
   }
 

--- a/src/static/stylesheets/content.scss
+++ b/src/static/stylesheets/content.scss
@@ -229,7 +229,7 @@ pre,
 }
 
 .keys-table {
-  padding: 20px;
+  max-width: 700px;
 
   .header-rows {
     padding-bottom: 10px;
@@ -237,12 +237,16 @@ pre,
 
   .header-rows,
   .body-rows {
+    align-items: center;
     display: grid;
     gap: 10px; // sass-lint:disable-line no-misspelled-properties
     grid-template-columns: 1fr 2fr 50px;
+    padding: 5px 10px;
 
     .delete-button {
+      display: block;
       height: 20px;
+      margin: auto;
     }
   }
 }

--- a/src/static/stylesheets/content.scss
+++ b/src/static/stylesheets/content.scss
@@ -227,3 +227,23 @@ pre,
     margin: 0 0 $elv-spacing-s;
   }
 }
+
+.keys-table {
+  padding: 20px;
+
+  .header-rows {
+    padding-bottom: 10px;
+  }
+
+  .header-rows,
+  .body-rows {
+    display: grid;
+    gap: 10px; // sass-lint:disable-line no-misspelled-properties
+    grid-template-columns: 1fr 2fr 50px;
+
+    .delete-button {
+      height: 20px;
+    }
+  }
+}
+

--- a/src/utils/Helpers.js
+++ b/src/utils/Helpers.js
@@ -33,6 +33,10 @@ export const EqualAddress = (address1, address2) => {
   return FormatAddress(address1) === FormatAddress(address2);
 };
 
+export const AddressToHash = (address) => {
+  return Utils.AddressToHash(address);
+};
+
 export const Percentage = (done, total) => {
   return total > 0 ? `${(done * 100 / total).toFixed(1)}%` : "100.0%";
 };

--- a/src/utils/Helpers.js
+++ b/src/utils/Helpers.js
@@ -37,6 +37,10 @@ export const AddressToHash = (address) => {
   return Utils.AddressToHash(address);
 };
 
+export const HashToAddress = (hash) => {
+  return Utils.HashToAddress(hash);
+};
+
 export const Percentage = (done, total) => {
   return total > 0 ? `${(done * 100 / total).toFixed(1)}%` : "100.0%";
 };


### PR DESCRIPTION
Create section within Content Object Info that allows the owner to add and delete owner caps.

![image](https://user-images.githubusercontent.com/91760982/143944121-917ee2f9-2347-46dc-88d1-26bb160ae27f.png)
As a non-owner:
![image](https://user-images.githubusercontent.com/91760982/143945866-03a5ba1b-e2ee-479c-af60-3179e7a77d78.png)


![Screen Shot 2021-11-22 at 5 52 16 PM](https://user-images.githubusercontent.com/91760982/142960416-db4a557f-5e9c-458f-8e4f-3bd909f5c891.png)

https://user-images.githubusercontent.com/91760982/142531271-a7a1dae5-e6d3-4573-bdf8-b3f6c6493301.mov



Expected/Tested
- Do not show current user cap within Encryption Keys section
- Encryption keys only viewable to non-owners (not editable)
- Users with owner cap and view/manage permissions can download/upload encrypted files
- User with view permission and no owner cap still able to access but not upload/download
- Throw error if attempting to create an owner cap before owner has a user cap


Relates to #9 

See Client PR: https://github.com/eluv-io/elv-client-js/pull/129
See Core PR: https://github.com/eluv-io/elv-core-js/pull/25