### PR TITLE
Componentize actions toolbar and simplify

### DIFF
--- a/src/components/components/ActionsToolbar.js
+++ b/src/components/components/ActionsToolbar.js
@@ -27,33 +27,29 @@ const ActionsToolbar = observer(({actions, iconActions, showContentLookup=true})
 
   const HandleEscapeKey = (event) => {
     if(event.key === "Escape") {
-      this.HandleClickOutside(event);
+      setMoreOptionsToggle(false);
     }
-  };
-
-  const StringToKebabCase = (string) => {
-    return string.toLowerCase().replace(" ", "-");
   };
 
   useEffect(() => {
     document.addEventListener("mousedown", HandleClickOutside);
-    document.addEventListener("keyup", HandleEscapeKey);
+    document.addEventListener("keydown", HandleEscapeKey);
 
     return (() => {
       document.removeEventListener("mousedown", HandleClickOutside);
-      document.removeEventListener("keyup", HandleEscapeKey);
+      document.removeEventListener("keydown", HandleEscapeKey);
     });
   }, []);
 
   const visibleActions = actions.filter(action => !action.hidden);
 
   const primaryActions = (
-    visibleActions.slice(0, 2).map(action => {
+    visibleActions.slice(0, 2).map((action, index) => {
       const {key, type, path, onClick, label, className} = action;
 
       return (
         <Action
-          key={key || StringToKebabCase(label)}
+          key={key || index}
           type={type}
           to={path}
           onClick={onClick}
@@ -78,12 +74,12 @@ const ActionsToolbar = observer(({actions, iconActions, showContentLookup=true})
         <div className={`more-options-menu ${moreOptionsOpen ? "more-options-menu--open" : ""}`}>
           <ul className="options-list" role="menu">
             {
-              visibleActions.slice(2).map(action => {
+              visibleActions.slice(2).map((action, index) => {
                 const {key, type, path, onClick, label, className, dividerAbove} = action;
 
                 return (
                   <Action
-                    key={key || StringToKebabCase(label)}
+                    key={key || index}
                     className={`list-item${dividerAbove ? " list-divider" : ""}${className ? " list-item-" + className : ""}`}
                     type={type}
                     button={false}
@@ -104,7 +100,7 @@ const ActionsToolbar = observer(({actions, iconActions, showContentLookup=true})
     );
   };
 
-  const iconActionElements = iconActions ? iconActions.map(action => {
+  const iconActionElements = iconActions ? iconActions.map((action, index) => {
     const {className, icon, label, onClick, key} = action;
 
     return (
@@ -113,7 +109,7 @@ const ActionsToolbar = observer(({actions, iconActions, showContentLookup=true})
         icon={icon}
         label={label}
         onClick={onClick}
-        key={key || StringToKebabCase(label)}
+        key={key || index}
       />
     );
   }) : null;

--- a/src/components/components/ActionsToolbar.js
+++ b/src/components/components/ActionsToolbar.js
@@ -1,0 +1,141 @@
+import React, {useEffect, useRef, useState} from "react";
+import {Action, IconButton} from "elv-components-js";
+import ContentLookup from "./ContentLookup";
+import {objectStore} from "../../stores";
+import {observer} from "mobx-react";
+
+const ActionsToolbar = observer(({actions, iconActions, showContentLookup=true}) => {
+  const [moreOptionsOpen, setMoreOptionsToggle] = useState(false);
+  const outsideContainerRef = useRef(null);
+
+  if(!actions) { actions = []; }
+
+  let saveDraftButton;
+  if(objectStore.writeTokens[objectStore.objectId]) {
+    saveDraftButton = (
+      <Action className="important" onClick={() => this.SaveContentObjectDraft()}>
+        Save Draft
+      </Action>
+    );
+  }
+
+  const HandleClickOutside = (event) => {
+    if(outsideContainerRef.current && !outsideContainerRef.current.contains(event.target)) {
+      setMoreOptionsToggle(false);
+    }
+  };
+
+  const HandleEscapeKey = (event) => {
+    if(event.key === "Escape") {
+      this.HandleClickOutside(event);
+    }
+  };
+
+  const StringToKebabCase = (string) => {
+    return string.toLowerCase().replace(" ", "-");
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", HandleClickOutside);
+    document.addEventListener("keyup", HandleEscapeKey);
+
+    return (() => {
+      document.removeEventListener("mousedown", HandleClickOutside);
+      document.removeEventListener("keyup", HandleEscapeKey);
+    });
+  }, []);
+
+  const visibleActions = actions.filter(action => !action.hidden);
+
+  const primaryActions = (
+    visibleActions.slice(0, 2).map(action => {
+      const {key, type, path, onClick, label, className} = action;
+
+      return (
+        <Action
+          key={key || StringToKebabCase(label)}
+          type={type}
+          to={path}
+          onClick={onClick}
+          className={`list-item${className ? " " + className : ""}`}
+        >
+          {label}
+        </Action>
+      );
+    })
+  );
+
+  const MoreOptionsDropdown = () => {
+    if(visibleActions.length < 3) {
+      return null;
+    }
+
+    return (
+      <div className="more-options-container" ref={outsideContainerRef}>
+        <Action type="button" onClick={() => setMoreOptionsToggle(prevState => !prevState)}>
+          <span className="more-options-text">More Options</span>
+        </Action>
+        <div className={`more-options-menu ${moreOptionsOpen ? "more-options-menu--open" : ""}`}>
+          <ul className="options-list" role="menu">
+            {
+              visibleActions.slice(2).map(action => {
+                const {key, type, path, onClick, label, className, dividerAbove} = action;
+
+                return (
+                  <Action
+                    key={key || StringToKebabCase(label)}
+                    className={`list-item${dividerAbove ? " list-divider" : ""}${className ? " list-item-" + className : ""}`}
+                    type={type}
+                    button={false}
+                    to={path}
+                    onClick={() => {
+                      setMoreOptionsToggle(false);
+                      onClick();
+                    }}
+                  >
+                    {label}
+                  </Action>
+                );
+              })
+            }
+          </ul>
+        </div>
+      </div>
+    );
+  };
+
+  const iconActionElements = iconActions ? iconActions.map(action => {
+    const {className, icon, label, onClick, key} = action;
+
+    return (
+      <IconButton
+        className={className}
+        icon={icon}
+        label={label}
+        onClick={onClick}
+        key={key || StringToKebabCase(label)}
+      />
+    );
+  }) : null;
+
+  return (
+    <div className="actions-wrapper">
+      <div className="actions-container">
+        <div className="left-action-buttons">
+          { primaryActions }
+          { MoreOptionsDropdown() }
+          { saveDraftButton }
+        </div>
+        {
+          (iconActionElements || showContentLookup) ?
+            <div className="right-action-buttons">
+              <ContentLookup />
+              { iconActionElements }
+            </div> : null
+        }
+      </div>
+    </div>
+  );
+});
+
+export default ActionsToolbar;

--- a/src/components/pages/access_groups/AccessGroup.js
+++ b/src/components/pages/access_groups/AccessGroup.js
@@ -6,7 +6,7 @@ import {LabelledField} from "../../components/LabelledField";
 import ClippedText from "../../components/ClippedText";
 import {Redirect} from "react-router";
 import {PageHeader} from "../../components/Page";
-import {Action, Confirm, IconButton, Tabs} from "elv-components-js";
+import {Confirm, IconButton, Tabs} from "elv-components-js";
 import Listing from "../../components/Listing";
 import RemoveIcon from "../../../static/icons/close.svg";
 import {inject, observer} from "mobx-react";
@@ -14,7 +14,7 @@ import AsyncComponent from "elv-components-js/src/components/AsyncComponent";
 import JSONField from "../../components/JSONField";
 import ToggleSection from "../../components/ToggleSection";
 import ContentObjectGroups from "../content/ContentObjectGroups";
-import ContentLookup from "../../components/ContentLookup";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("groupStore")
 @observer
@@ -148,16 +148,42 @@ class AccessGroup extends React.Component {
 
   Actions() {
     return (
-      <div className="actions-wrapper">
-        <div className="actions-container content-lookup-actions-container">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary" >Back</Action>
-          <Action type="link" to={UrlJoin(this.props.match.url, "edit")} hidden={!this.props.groupStore.accessGroup.isOwner}>Manage</Action>
-          <Action type="link" to={UrlJoin(this.props.match.url, "add-member")} hidden={!this.props.groupStore.accessGroup.isManager}>Add Member</Action>
-          <Action className="danger" onClick={this.LeaveAccessGroup} hidden={this.props.groupStore.accessGroup.isOwner}>Leave Group</Action>
-          <Action className="danger" onClick={this.DeleteAccessGroup} hidden={true || !this.props.groupStore.accessGroup.isOwner}>Delete</Action>
-          <ContentLookup />
-        </div>
-      </div>
+      <ActionsToolbar
+        actions={[
+          {
+            label: "Back",
+            type: "link",
+            path: Path.dirname(this.props.match.url),
+            className: "secondary"
+          },
+          {
+            label: "Manage",
+            type: "link",
+            hidden: !this.props.groupStore.accessGroup.isOwner,
+            path: UrlJoin(this.props.match.url, "edit"),
+          },
+          {
+            label: "Add Member",
+            type: "link",
+            hidden: !this.props.groupStore.accessGroup.isManager,
+            path: UrlJoin(this.props.match.url, "add-member")
+          },
+          {
+            label: "Leave Group",
+            type: "button",
+            hidden: this.props.groupStore.accessGroup.isOwner,
+            onClick: this.LeaveAccessGroup,
+            className: "danger"
+          },
+          {
+            label: "Delete",
+            type: "button",
+            hidden: (true || !this.props.groupStore.accessGroup.isOwner),
+            onClick: this.DeleteAccessGroup,
+            className: "danger"
+          }
+        ]}
+      />
     );
   }
 

--- a/src/components/pages/access_groups/AccessGroup.js
+++ b/src/components/pages/access_groups/AccessGroup.js
@@ -172,14 +172,14 @@ class AccessGroup extends React.Component {
             label: "Leave Group",
             type: "button",
             hidden: this.props.groupStore.accessGroup.isOwner,
-            onClick: this.LeaveAccessGroup,
+            onClick: () => this.LeaveAccessGroup(),
             className: "danger"
           },
           {
             label: "Delete",
             type: "button",
             hidden: (true || !this.props.groupStore.accessGroup.isOwner),
-            onClick: this.DeleteAccessGroup,
+            onClick: () => this.DeleteAccessGroup(),
             className: "danger"
           }
         ]}

--- a/src/components/pages/access_groups/AccessGroupForm.js
+++ b/src/components/pages/access_groups/AccessGroupForm.js
@@ -1,7 +1,7 @@
 import React from "react";
 import UrlJoin from "url-join";
 import Path from "path";
-import {Action, Form, IconButton} from "elv-components-js";
+import {Form, IconButton} from "elv-components-js";
 import {inject, observer} from "mobx-react";
 import AsyncComponent from "../../components/AsyncComponent";
 import JsonTextArea from "elv-components-js/src/components/JsonInput";
@@ -10,6 +10,7 @@ import Fabric from "../../../clients/Fabric";
 
 import AddIcon from "../../../static/icons/plus-square.svg";
 import RemoveIcon from "../../../static/icons/minus-square.svg";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("groupStore")
 @observer
@@ -144,9 +145,17 @@ class AccessGroupForm extends React.Component {
 
     return (
       <div className="page-container">
-        <div className="actions-container manage-actions">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">Back</Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            },
+          ]}
+        />
         <div className="page-content-container">
           <div className="page-content">
             <Form
@@ -154,6 +163,7 @@ class AccessGroupForm extends React.Component {
               redirectPath={redirectPath}
               cancelPath={backPath}
               OnSubmit={this.HandleSubmit}
+              className="form-page"
             >
               <div className="form-content">
                 <label htmlFor="name">Name</label>

--- a/src/components/pages/access_groups/AccessGroupMemberForm.js
+++ b/src/components/pages/access_groups/AccessGroupMemberForm.js
@@ -1,8 +1,9 @@
 import React from "react";
 import Path from "path";
-import {Action, Form} from "elv-components-js";
+import {Form} from "elv-components-js";
 import {inject, observer} from "mobx-react";
 import {AsyncComponent} from "elv-components-js";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("groupStore")
 @observer
@@ -39,17 +40,23 @@ class AccessGroupMemberForm extends React.Component {
 
     return (
       <div className="page-container">
-        <div className="actions-container manage-actions">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">
-            Back
-          </Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <Form
           legend={`Add member to '${this.props.groupStore.accessGroup.name}'`}
           redirectPath={backPath}
           cancelPath={backPath}
           OnSubmit={this.HandleSubmit}
-          className="small-form"
+          className="small-form form-page"
         >
           <div className="form-content">
             <label htmlFor="memberAddress">Address</label>

--- a/src/components/pages/access_groups/AccessGroups.js
+++ b/src/components/pages/access_groups/AccessGroups.js
@@ -2,10 +2,9 @@ import React from "react";
 import UrlJoin from "url-join";
 import AccessGroupIcon from "../../../static/icons/groups.svg";
 import {PageHeader} from "../../components/Page";
-import {Action} from "elv-components-js";
 import Listing from "../../components/Listing";
 import {inject, observer} from "mobx-react";
-import ContentLookup from "../../components/ContentLookup";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("groupStore")
 @observer
@@ -57,10 +56,15 @@ class AccessGroups extends React.Component {
   render() {
     return (
       <div className="page-container contents-page-container">
-        <div className="actions-container content-lookup-actions-container">
-          <Action type="link" to="/access-groups/create">New Access Group</Action>
-          <ContentLookup />
-        </div>
+        <ActionsToolbar
+          actions={[
+            {
+              label: "New Access Group",
+              type: "link",
+              path: "/access-groups/create"
+            }
+          ]}
+        />
         <PageHeader header="Access Groups" />
         <div className="page-content">
           { this.AccessGroupsListing() }

--- a/src/components/pages/content/ContentApps.js
+++ b/src/components/pages/content/ContentApps.js
@@ -6,6 +6,7 @@ import {Action, Form, Modal} from "elv-components-js";
 import FileUploadWidget from "../../components/FileUploadWidget";
 import {inject, observer} from "mobx-react";
 import AsyncComponent from "../../components/AsyncComponent";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 const appNames = {
   "asset-manager": "Asset Manager",
@@ -166,9 +167,17 @@ class ContentApps extends React.Component {
 
     return (
       <div className="page-container contracts-page-container">
-        <div className="actions-container">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">Back</Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <PageHeader header={header} />
         <div className="page-content-container">
           <div className="page-content">

--- a/src/components/pages/content/ContentLibraries.js
+++ b/src/components/pages/content/ContentLibraries.js
@@ -2,10 +2,9 @@ import React from "react";
 import UrlJoin from "url-join";
 import LibraryIcon from "../../../static/icons/content.svg";
 import {PageHeader} from "../../components/Page";
-import {Action} from "elv-components-js";
 import Listing from "../../components/Listing";
 import {inject, observer} from "mobx-react";
-import ContentLookup from "../../components/ContentLookup";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("libraryStore")
 @observer
@@ -39,10 +38,15 @@ class ContentLibraries extends React.Component {
     // This is the root component, actual path may be "/content" or "/"
     return (
       <div className="page-container contents-page-container">
-        <div className="actions-container content-lookup-actions-container">
-          <Action type="link" to={UrlJoin("/content", "create")}>New Library</Action>
-          <ContentLookup />
-        </div>
+        <ActionsToolbar
+          actions={[
+            {
+              label: "New Library",
+              type: "link",
+              path: UrlJoin("/content", "create")
+            }
+          ]}
+        />
         <PageHeader header="Content Libraries" />
         <div className="page-content-container">
           <div className="page-content">

--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -6,7 +6,7 @@ import ContentIcon from "../../../static/icons/content.svg";
 import {LabelledField} from "../../components/LabelledField";
 import ClippedText from "../../components/ClippedText";
 import {PageHeader} from "../../components/Page";
-import {Action, IconButton, Tabs} from "elv-components-js";
+import {Action, Tabs} from "elv-components-js";
 import AsyncComponent from "../../components/AsyncComponent";
 
 import Listing from "../../components/Listing";
@@ -15,9 +15,9 @@ import RefreshIcon from "../../../static/icons/refresh.svg";
 import ToggleSection from "../../components/ToggleSection";
 import JSONField from "../../components/JSONField";
 import ContentLibraryGroupForm from "./ContentLibraryGroupForm";
-import ContentLookup from "../../components/ContentLookup";
 import {ContentBrowserModal} from "../../components/ContentBrowser";
 import {Redirect} from "react-router";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("libraryStore")
 @inject("groupStore")
@@ -293,75 +293,52 @@ class ContentLibrary extends React.Component {
   }
 
   Actions() {
-    const refreshButton = (
-      <IconButton
-        className="refresh-button"
-        icon={RefreshIcon}
-        label="Refresh"
-        onClick={() => {
-          this.props.libraryStore.ClearLibraryCache({libraryId: this.props.libraryStore.libraryId});
-          this.setState({pageVersion: this.state.pageVersion + 1});
-        }}
-      />
-    );
-
-    const backButton = (
-      <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">
-        Back
-      </Action>
-    );
-
-    let createButton;
-    if(this.props.libraryStore.library.canContribute) {
-      createButton = (
-        <Action type="link" to={UrlJoin(this.props.match.url, "create")}>
-          {this.props.libraryStore.library.isContentSpaceLibrary ? "New Content Type" : "Create"}
-        </Action>
-      );
-    }
-
-    let createFromExistingButton;
-    if(this.props.libraryStore.library.canContribute && !this.props.libraryStore.library.isContentSpaceLibrary) {
-      createFromExistingButton = (
-        <Action type="button" onClick={() => this.setState({showCopyObjectModal: true})}>
-          Create From Existing
-        </Action>
-      );
-    }
-
-    if(!this.props.libraryStore.library.isOwner) {
-      return (
-        <div className="actions-wrapper">
-          <div className="actions-container">
-            <ContentLookup />
-          </div>
-          <div className="actions-container">
-            { backButton }
-            { createButton }
-            { refreshButton }
-          </div>
-        </div>
-      );
-    }
-
     return (
-      <div className="actions-wrapper">
-        <div className="actions-container">
-          <ContentLookup />
-        </div>
-        <div className="actions-container">
-          { backButton }
-          <Action type="link" to={UrlJoin(this.props.match.url, "edit")}>
-            Manage
-          </Action>
-          <Action type="link" to={UrlJoin(this.props.match.url, "types")}>
-            Types
-          </Action>
-          { createButton }
-          { createFromExistingButton }
-          { refreshButton }
-        </div>
-      </div>
+      <ActionsToolbar
+        iconActions={[
+          {
+            className: "refresh-button",
+            icon: RefreshIcon,
+            label: "Refresh",
+            onClick: () => {
+              this.props.libraryStore.ClearLibraryCache({libraryId: this.props.libraryStore.libraryId});
+              this.setState({pageVersion: this.state.pageVersion + 1});
+            }
+          }
+        ]}
+        actions={[
+          {
+            label: "Back",
+            type: "link",
+            path: Path.dirname(this.props.match.url),
+            className: "secondary"
+          },
+          {
+            label: "Manage",
+            type: "link",
+            hidden: !this.props.libraryStore.library.isOwner,
+            path: UrlJoin(this.props.match.url, "edit"),
+          },
+          {
+            label: "Types",
+            type: "link",
+            hidden: !this.props.libraryStore.library.isOwner,
+            path: UrlJoin(this.props.match.url, "types")
+          },
+          {
+            label: this.props.libraryStore.library.isContentSpaceLibrary ? "New Content Type" : "Create",
+            type: "link",
+            hidden: !this.props.libraryStore.library.canContribute,
+            path: UrlJoin(this.props.match.url, "create")
+          },
+          {
+            label: "Create From Existing",
+            type: "button",
+            hidden: this.props.libraryStore.library.isContentSpaceLibrary || !(this.props.libraryStore.library.isOwner && this.props.libraryStore.library.canContribute),
+            onClick: () => this.setState({showCopyObjectModal: true})
+          }
+        ]}
+      />
     );
   }
 

--- a/src/components/pages/content/ContentLibraryForm.js
+++ b/src/components/pages/content/ContentLibraryForm.js
@@ -1,9 +1,10 @@
 import React from "react";
 import UrlJoin from "url-join";
 import Path from "path";
-import {Action, BrowseWidget, Form, JsonInput} from "elv-components-js";
+import {BrowseWidget, Form, JsonInput} from "elv-components-js";
 import {inject, observer} from "mobx-react";
 import AsyncComponent from "../../components/AsyncComponent";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("libraryStore")
 @observer
@@ -87,9 +88,17 @@ class ContentLibraryForm extends React.Component {
 
     return (
       <div className="page-container">
-        <div className="actions-container manage-actions">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">Back</Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <div className="page-content-container">
           <div className="page-content">
             <Form
@@ -97,6 +106,7 @@ class ContentLibraryForm extends React.Component {
               redirectPath={redirectPath}
               cancelPath={Path.dirname(this.props.match.url)}
               OnSubmit={this.HandleSubmit}
+              className="form-page"
             >
               <div className="form-content">
                 <label htmlFor="name">Name</label>

--- a/src/components/pages/content/ContentLibraryTypesForm.js
+++ b/src/components/pages/content/ContentLibraryTypesForm.js
@@ -4,6 +4,7 @@ import {Action, Form, IconButton} from "elv-components-js";
 import AsyncComponent from "../../components/AsyncComponent";
 import DeleteIcon from "../../../static/icons/trash.svg";
 import {inject, observer} from "mobx-react";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("libraryStore")
 @inject("typeStore")
@@ -117,15 +118,23 @@ class ContentLibraryTypesForm extends React.Component {
   PageContent() {
     return (
       <div className="page-container">
-        <div className="actions-container manage-actions">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">Back</Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <Form
           legend={"Manage Library Types"}
           redirectPath={Path.dirname(this.props.match.url)}
           cancelPath={Path.dirname(this.props.match.url)}
           OnSubmit={this.HandleSubmit}
-          className="small-form"
+          className="small-form form-page"
         >
           <div className="form-content">
             <label htmlFor={"typeId"}>Content Types</label>

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -21,10 +21,11 @@ import ContentObjectGroups from "./ContentObjectGroups";
 
 import RefreshIcon from "../../../static/icons/refresh.svg";
 import InfoIcon from "../../../static/icons/help-circle.svg";
-import Diff from "../../components/Diff";
-import ContentLookup from "../../components/ContentLookup";
-import {ContentBrowserModal} from "../../components/ContentBrowser";
 import DeleteIcon from "../../../static/icons/trash.svg";
+
+import Diff from "../../components/Diff";
+import {ContentBrowserModal} from "../../components/ContentBrowser";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 const DownloadPart = ({libraryId, objectId, versionHash, partHash, partName, DownloadMethod}) => {
   const [progress, setProgress] = useState(undefined);
@@ -812,94 +813,63 @@ class ContentObject extends React.Component {
   }
 
   Actions() {
-    const object = this.props.objectStore.object;
-
-    const refreshButton = (
-      <IconButton
-        className="refresh-button"
-        icon={RefreshIcon}
-        label="Refresh"
-        onClick={() => this.setState({pageVersion: this.state.pageVersion + 1})}
-      />
-    );
-
-    const backButton = (
-      <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">
-        Back
-      </Action>
-    );
-
-    if(!object.canEdit) {
-      return (
-        <div className="actions-wrapper">
-          <div className="actions-container">
-            <ContentLookup />
-          </div>
-          <div className="actions-container">
-            { backButton }
-            { refreshButton }
-          </div>
-        </div>
-      );
-    }
-
-    let setContractButton;
-    if(
-      !object.customContractAddress &&
-      (object.isNormalObject || object.isContentType)
-    ) {
-      setContractButton = (
-        <Action type="link" to={UrlJoin(this.props.match.url, "deploy")}>
-          Custom Contract
-        </Action>
-      );
-    }
-
-    let deleteObjectButton;
-    if(object.isOwner && !object.isContentLibraryObject) {
-      deleteObjectButton = (
-        <Action className="danger" onClick={() => this.DeleteContentObject()}>
-          Delete
-        </Action>
-      );
-    }
-
-    let saveDraftButton;
-    if(this.props.objectStore.writeTokens[this.props.objectStore.objectId]) {
-      saveDraftButton = (
-        <Action className="important" onClick={() => this.SaveContentObjectDraft()}>
-          Save Draft
-        </Action>
-      );
-    }
-
-    const copyObjectButton = (
-      <Action className="primary" onClick={() => this.setState({showCopyObjectModal: true})}>
-        Copy
-      </Action>
-    );
-
     return (
-      <div className="actions-wrapper">
-        <div className="actions-container">
-          <ContentLookup />
-        </div>
-        <div className="actions-container">
-          { backButton }
-          <Action type="link" to={UrlJoin(this.props.match.url, "edit")}>Manage</Action>
-          { setContractButton }
-          <Action type="link" to={UrlJoin(this.props.match.url, "upload")}>
-            Upload Parts
-          </Action>
-          <Action type="link" to={UrlJoin(this.props.match.url, "apps")}>
-            Apps
-          </Action>
-          { copyObjectButton }
-          { deleteObjectButton }
-          { saveDraftButton }
-          { refreshButton }
-        </div>
-      </div>
+      <ActionsToolbar
+        iconActions={[
+          {
+            className: "refresh-button",
+            icon: RefreshIcon,
+            label: "Refresh",
+            onClick: () => this.setState({pageVersion: this.state.pageVersion + 1})
+          }
+        ]}
+        actions={[
+          {
+            label: "Back",
+            type: "link",
+            path: Path.dirname(this.props.match.url),
+            className: "secondary"
+          },
+          {
+            label: "Manage",
+            type: "link",
+            hidden: !this.props.objectStore.object.canEdit,
+            path: UrlJoin(this.props.match.url, "edit"),
+          },
+          {
+            label: "Custom Contract",
+            type: "link",
+            hidden: !this.props.objectStore.object.canEdit || this.props.objectStore.object.customContractAddress || !(this.props.objectStore.object.isNormalObject || this.props.objectStore.object.isContentType),
+            path: UrlJoin(this.props.match.url, "deploy"),
+          },
+          {
+            label: "Upload Parts",
+            type: "link",
+            hidden: !this.props.objectStore.object.canEdit,
+            path: UrlJoin(this.props.match.url, "upload")
+          },
+          {
+            label: "Apps",
+            type: "link",
+            hidden: !this.props.objectStore.object.canEdit,
+            path: UrlJoin(this.props.match.url, "apps")
+          },
+          {
+            label: "Copy",
+            type: "button",
+            hidden: !this.props.objectStore.object.canEdit,
+            onClick: () => this.setState({showCopyObjectModal: true})
+          },
+          {
+            label: "Delete",
+            type: "button",
+            hidden: this.props.objectStore.object.isContentLibraryObject || !this.props.objectStore.object.canEdit || !this.props.objectStore.object.isOwner,
+            onClick: () => this.DeleteContentObject(),
+            className: "danger",
+            dividerAbove: true
+          }
+        ]}
+      />
     );
   }
 

--- a/src/components/pages/content/ContentObjectForm.js
+++ b/src/components/pages/content/ContentObjectForm.js
@@ -1,13 +1,14 @@
 import React from "react";
 import UrlJoin from "url-join";
 import Path from "path";
-import {Action, BrowseWidget, Form, JsonInput, LoadingElement, Tabs} from "elv-components-js";
+import {BrowseWidget, Form, JsonInput, LoadingElement, Tabs} from "elv-components-js";
 import {inject, observer} from "mobx-react";
 import AsyncComponent from "../../components/AsyncComponent";
 import {Redirect} from "react-router";
 import {toJS} from "mobx";
 import Fabric from "../../../clients/Fabric";
 import AppFrame from "../../components/AppFrame";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("libraryStore")
 @inject("objectStore")
@@ -128,6 +129,7 @@ class ContentObjectForm extends React.Component {
         redirectPath={redirectPath}
         cancelPath={backPath}
         OnSubmit={this.HandleSubmit}
+        className="form-page"
       >
         <div className="form-content">
           <label htmlFor="name">Name</label>
@@ -171,16 +173,6 @@ class ContentObjectForm extends React.Component {
         onChange={(value) => this.setState({showManageApp: value})}
         options={[["App", true], ["Form", false]]}
       />
-    );
-  }
-
-  BackLink() {
-    if(this.state.fullScreen) { return; }
-
-    return (
-      <div className="actions-container manage-actions">
-        <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">Back</Action>
-      </div>
     );
   }
 
@@ -228,7 +220,18 @@ class ContentObjectForm extends React.Component {
 
     return (
       <div className="page-container">
-        { this.BackLink() }
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              hidden: this.state.fullScreen,
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <div className="page-content-container">
           <div className={`page-content ${this.state.showManageApp ? "no-padding" : ""}`}>
             { this.AppFormSelection() }

--- a/src/components/pages/content/ContentObjectForm.js
+++ b/src/components/pages/content/ContentObjectForm.js
@@ -232,7 +232,7 @@ class ContentObjectForm extends React.Component {
             }
           ]}
         />
-        <div className="page-content-container">
+        <div className="page-content-container form-page">
           <div className={`page-content ${this.state.showManageApp ? "no-padding" : ""}`}>
             { this.AppFormSelection() }
             { content }

--- a/src/components/pages/content/ContentObjectPartsForm.js
+++ b/src/components/pages/content/ContentObjectPartsForm.js
@@ -1,9 +1,10 @@
 import React from "react";
 import Path from "path";
-import {Action, BrowseWidget, Form} from "elv-components-js";
+import {BrowseWidget, Form} from "elv-components-js";
 import AsyncComponent from "../../components/AsyncComponent";
 import {inject, observer} from "mobx-react";
 import {Percentage} from "../../../utils/Helpers";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("objectStore")
 @observer
@@ -51,14 +52,22 @@ class ContentObjectPartsForm extends React.Component {
   PageContent() {
     return (
       <div className="page-container">
-        <div className="actions-container manage-actions">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">Back</Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <Form
           legend={`Upload parts to ${this.props.objectStore.object.meta.name || this.props.objectStore.objectId}`}
           redirectPath={Path.dirname(this.props.match.url)}
           cancelPath={Path.dirname(this.props.match.url)}
-          className="small-form"
+          className="small-form form-page"
           OnSubmit={this.HandleSubmit}
         >
           <div className="form-content">

--- a/src/components/pages/content/ContentObjectReviewForm.js
+++ b/src/components/pages/content/ContentObjectReviewForm.js
@@ -1,11 +1,12 @@
 import React from "react";
 import Path from "path";
-import {Action, Form, RadioSelect} from "elv-components-js";
+import {Form, RadioSelect} from "elv-components-js";
 import AsyncComponent from "../../components/AsyncComponent";
 import AppFrame from "../../components/AppFrame";
 import Fabric from "../../../clients/Fabric";
 import {Redirect} from "react-router";
 import {inject, observer} from "mobx-react";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("objectStore")
 @observer
@@ -62,9 +63,17 @@ class ContentObjectReviewForm extends React.Component {
             onComplete={this.FrameCompleted}
             onCancel={this.FrameCompleted}
           />
-          <div className="actions-container">
-            <Action className="secondary" onClick={this.FrameCompleted}>Cancel</Action>
-          </div>
+          <ActionsToolbar
+            showContentLookup={false}
+            actions={[
+              {
+                label: "Cancel",
+                type: "button",
+                onClick: this.FrameCompleted,
+                className: "secondary"
+              }
+            ]}
+          />
         </fieldset>
       </form>
     );
@@ -81,15 +90,24 @@ class ContentObjectReviewForm extends React.Component {
       return this.ReviewAppFrame(legend);
     } else {
       return (
-        <div>
-          <div className="actions-container manage-actions">
-            <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">Back</Action>
-          </div>
+        <div className="page-container">
+          <ActionsToolbar
+            showContentLookup={false}
+            actions={[
+              {
+                label: "Back",
+                type: "link",
+                path: Path.dirname(this.props.match.url),
+                className: "secondary"
+              }
+            ]}
+          />
           <Form
             legend={legend}
             redirectPath={Path.dirname(this.props.match.url)}
             cancelPath={Path.dirname(this.props.match.url)}
             OnSubmit={this.HandleSubmit}
+            className="form-page"
           >
             <div className="form-content">
               <label htmlFor="approve">Approval</label>

--- a/src/components/pages/content/ContentObjectReviewForm.js
+++ b/src/components/pages/content/ContentObjectReviewForm.js
@@ -69,7 +69,7 @@ class ContentObjectReviewForm extends React.Component {
               {
                 label: "Cancel",
                 type: "button",
-                onClick: this.FrameCompleted,
+                onClick: () => this.FrameCompleted(),
                 className: "secondary"
               }
             ]}

--- a/src/components/pages/content/ContentTypeForm.js
+++ b/src/components/pages/content/ContentTypeForm.js
@@ -1,9 +1,10 @@
 import React from "react";
 import UrlJoin from "url-join";
 import Path from "path";
-import {Action, BrowseWidget, Form, JsonInput, Maybe} from "elv-components-js";
+import {BrowseWidget, Form, JsonInput, Maybe} from "elv-components-js";
 import AsyncComponent from "../../components/AsyncComponent";
 import {inject, observer} from "mobx-react";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("typeStore")
 @observer
@@ -79,15 +80,24 @@ class ContentTypeForm extends React.Component {
 
     return (
       <div className="page-container">
-        <div className="actions-container manage-actions">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">Back</Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <div className="page-content">
           <Form
             legend={legend}
             redirectPath={redirectPath}
             cancelPath={backPath}
             OnSubmit={this.HandleSubmit}
+            className="form-page"
           >
             <div className="form-content">
               <label htmlFor="name">Name</label>

--- a/src/components/pages/content/ContentTypes.js
+++ b/src/components/pages/content/ContentTypes.js
@@ -2,10 +2,9 @@ import React from "react";
 import UrlJoin from "url-join";
 import TypeIcon from "../../../static/icons/content.svg";
 import {PageHeader} from "../../components/Page";
-import {Action} from "elv-components-js";
 import Listing from "../../components/Listing";
 import {inject, observer} from "mobx-react";
-import ContentLookup from "../../components/ContentLookup";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("typeStore")
 @observer
@@ -41,10 +40,15 @@ class ContentTypes extends React.Component {
   render() {
     return (
       <div className="page-container contents-page-container">
-        <div className="actions-container content-lookup-actions-container">
-          <Action type="link" to={UrlJoin("/content-types", "create")}>New Content Type</Action>
-          <ContentLookup />
-        </div>
+        <ActionsToolbar
+          actions={[
+            {
+              label: "New Content Type",
+              type: "link",
+              path: UrlJoin("/content-types", "create")
+            }
+          ]}
+        />
         <PageHeader header="Content Types" />
         <div className="page-content-container">
           <div className="page-content">

--- a/src/components/pages/contracts/CompileContractForm.js
+++ b/src/components/pages/contracts/CompileContractForm.js
@@ -1,8 +1,9 @@
 import React from "react";
-import {Action, BrowseWidget, Form, JsonInput, RadioSelect} from "elv-components-js";
+import {BrowseWidget, Form, JsonInput, RadioSelect} from "elv-components-js";
 import UrlJoin from "url-join";
 import Path from "path";
 import {inject, observer} from "mobx-react";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("contractStore")
 @observer
@@ -119,16 +120,24 @@ class CompileContractForm extends React.Component {
 
     return (
       <div className="page-container">
-        <div className="actions-container manage-actions">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">Back</Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <Form
           legend={"Compile contracts"}
           redirectPath={redirectPath}
           cancelPath={backPath}
           status={status}
           OnSubmit={this.HandleSubmit}
-          className="small-form"
+          className="small-form form-page"
         >
           <div>
             <div className="form-content">

--- a/src/components/pages/contracts/Contract.js
+++ b/src/components/pages/contracts/Contract.js
@@ -8,6 +8,7 @@ import {PageHeader} from "../../components/Page";
 import {Action, Confirm} from "elv-components-js";
 import {inject, observer} from "mobx-react";
 import AsyncComponent from "../../components/AsyncComponent";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("contractStore")
 @observer
@@ -96,12 +97,34 @@ class Contract extends React.Component {
 
     return (
       <div className="page-container contracts-page-container">
-        <div className="actions-container">
-          <Action type="link" to={"/contracts/saved"} className="secondary">Back</Action>
-          <Action type="link" to={UrlJoin(this.props.match.url, "edit")}>Edit Contract</Action>
-          <Action type="link" to={UrlJoin(this.props.match.url, "deploy")}>Deploy Contract</Action>
-          <Action className="danger" onClick={this.DeleteContract}>Delete Contract</Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: "/contracts/saved",
+              className: "secondary"
+            },
+            {
+              label: "Edit Contract",
+              type: "link",
+              path: UrlJoin(this.props.match.url, "edit")
+            },
+            {
+              label: "Deploy Contract",
+              type: "link",
+              path: UrlJoin(this.props.match.url, "deploy")
+            },
+            {
+              label: "Delete Contract",
+              type: "button",
+              onClick: this.DeleteContract,
+              className: "danger",
+              dividerAbove: true
+            }
+          ]}
+        />
         <PageHeader header={this.props.contractStore.contractName} />
         <div className="page-content-container">
           <div className="page-content">

--- a/src/components/pages/contracts/Contract.js
+++ b/src/components/pages/contracts/Contract.js
@@ -119,7 +119,7 @@ class Contract extends React.Component {
             {
               label: "Delete Contract",
               type: "button",
-              onClick: this.DeleteContract,
+              onClick: () => this.DeleteContract(),
               className: "danger",
               dividerAbove: true
             }

--- a/src/components/pages/contracts/ContractForm.js
+++ b/src/components/pages/contracts/ContractForm.js
@@ -1,10 +1,11 @@
 import React from "react";
 import {Redirect} from "react-router";
-import {Action, Form} from "elv-components-js";
+import {Form} from "elv-components-js";
 import AsyncComponent from "../../components/AsyncComponent";
 import Path from "path";
 import UrlJoin from "url-join";
 import {inject, observer} from "mobx-react";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("contractStore")
 @observer
@@ -96,14 +97,23 @@ class ContractForm extends React.Component {
 
     return (
       <div className="page-container">
-        <div className="actions-container manage-actions">
-          <Action type="link" to={backPath} className="secondary">Back</Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: backPath,
+              className: "secondary"
+            }
+          ]}
+        />
         <Form
           legend={this.state.createForm ? "Save contract" : "Edit Contract"}
           redirectPath={backPath}
           cancelPath={backPath}
           OnSubmit={this.HandleSubmit}
+          className="form-page"
         >
           <div className="form-content">
             <label htmlFor="name">Name</label>

--- a/src/components/pages/contracts/Contracts.js
+++ b/src/components/pages/contracts/Contracts.js
@@ -1,10 +1,10 @@
 import React from "react";
 import UrlJoin from "url-join";
 import {PageHeader} from "../../components/Page";
-import {Action, Tabs} from "elv-components-js";
+import {Tabs} from "elv-components-js";
 import Listing from "../../components/Listing";
 import {inject, observer} from "mobx-react";
-import ContentLookup from "../../components/ContentLookup";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("contractStore")
 @observer
@@ -99,14 +99,25 @@ class Contracts extends React.Component {
 
     return (
       <div className="page-container contents-page-container">
-        <div className="actions-wrapper">
-          <div className="actions-container content-lookup-actions-container">
-            <Action type="link" to="/contracts/compile">New Contract</Action>
-            <Action type="link" to="/contracts/deploy">Deploy Contract</Action>
-            <Action type="link" to="/contracts/watch">Watch Contract</Action>
-            <ContentLookup />
-          </div>
-        </div>
+        <ActionsToolbar
+          actions={[
+            {
+              label: "New Contract",
+              type: "link",
+              path: "/contracts/compile"
+            },
+            {
+              label: "Deploy Contract",
+              type: "link",
+              path: "/contracts/deploy"
+            },
+            {
+              label: "Watch Contract",
+              type: "link",
+              path: "/contracts/watch"
+            }
+          ]}
+        />
         <PageHeader header="Contracts" />
         { tabs }
         { this.ContractsListing() }

--- a/src/components/pages/contracts/DeployContractForm.js
+++ b/src/components/pages/contracts/DeployContractForm.js
@@ -2,9 +2,10 @@ import React from "react";
 import UrlJoin from "url-join";
 import Path from "path";
 import Fabric from "../../../clients/Fabric";
-import {Action, Form, JsonInput, RadioSelect} from "elv-components-js";
+import {Form, JsonInput, RadioSelect} from "elv-components-js";
 import AsyncComponent from "../../components/AsyncComponent";
 import {inject, observer} from "mobx-react";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("contractStore")
 @observer
@@ -319,16 +320,23 @@ class DeployContractForm extends React.Component {
 
     return (
       <div className="page-container">
-        <div className="actions-container manage-actions">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">
-            Back
-          </Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <Form
           legend={legend}
           redirectPath={redirectPath}
           cancelPath={backPath}
           OnSubmit={this.HandleSubmit}
+          className="form-page"
         >
           { this.ContractForm() }
         </Form>

--- a/src/components/pages/contracts/WatchContractForm.js
+++ b/src/components/pages/contracts/WatchContractForm.js
@@ -1,8 +1,9 @@
 import React from "react";
 import UrlJoin from "url-join";
 import Path from "path";
-import {Action, Form, JsonInput} from "elv-components-js";
+import {Form, JsonInput} from "elv-components-js";
 import {inject, observer} from "mobx-react";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 @inject("contractStore")
 @observer
@@ -41,14 +42,23 @@ class WatchContractForm extends React.Component {
 
     return (
       <div className="page-container">
-        <div className="actions-container manage-actions">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">Back</Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <Form
           legend={"Watch Deployed Contract"}
           redirectPath={redirectPath}
           cancelPath={Path.dirname(this.props.match.url)}
           OnSubmit={this.HandleSubmit}
+          className="form-page"
         >
           <div className="form-content">
             <label htmlFor="name">Name</label>

--- a/src/components/pages/contracts/deployed/DeployedContract.js
+++ b/src/components/pages/contracts/deployed/DeployedContract.js
@@ -11,6 +11,7 @@ import {inject, observer} from "mobx-react";
 import DeployedContractMethodForm from "./DeployedContractMethodForm";
 import JSONField from "../../../components/JSONField";
 import ToggleSection from "../../../components/ToggleSection";
+import ActionsToolbar from "../../../components/ActionsToolbar";
 
 @inject("contractStore")
 @observer
@@ -34,29 +35,47 @@ class DeployedContract extends React.Component {
     });
   }
 
-  // Allow removal (aka stop watching) deployed custom contract
-  DeleteButton() {
-    if(this.props.contractStore.contract.type !== ContractTypes.unknown) { return null; }
+  Actions = (backPath) => {
+    return <ActionsToolbar
+      showContentLookup={false}
+      actions={[
+        {
+          label: "Back",
+          type: "link",
+          path: backPath,
+          className: "secondary"
+        },
+        {
+          label: "Transfer Funds",
+          type: "link",
+          path: UrlJoin(this.props.match.url, "funds")
+        },
+        {
+          label: "Contract Events",
+          type: "link",
+          path: UrlJoin(this.props.match.url, "events")
+        },
+        // Allow removal (aka stop watching) deployed custom contract
+        {
+          label: "Remove Contract",
+          type: "button",
+          onClick: async() => {
+            await Confirm({
+              message: "Are you sure you want to stop watching this contract?",
+              onConfirm: async () => {
+                await this.props.contractStore.RemoveDeployedContract({
+                  address: this.props.contractStore.contractAddress
+                });
 
-    return (
-      <Action
-        className="danger"
-        onClick={async () => {
-          await Confirm({
-            message: "Are you sure you want to stop watching this contract?",
-            onConfirm: async () => {
-              await this.props.contractStore.RemoveDeployedContract({
-                address: this.props.contractStore.contractAddress
-              });
-
-              this.setState({removed: true});
-            }
-          });
-        }}
-      >
-        Remove Contract
-      </Action>
-    );
+                this.setState({removed: true});
+              }
+            });
+          },
+          dividerAbove: true,
+          className: "danger"
+        }
+      ]}
+    />;
   }
 
   ToggleElement(methodName) {
@@ -116,12 +135,7 @@ class DeployedContract extends React.Component {
 
     return (
       <div className="page-container contracts-page-container">
-        <div className="actions-container">
-          <Action type="link" to={backPath} className="secondary" >Back</Action>
-          <Action type="link" to={UrlJoin(this.props.match.url, "funds")}>Transfer Funds</Action>
-          <Action type="link" to={UrlJoin(this.props.match.url, "events")}>Contract Events</Action>
-          { this.DeleteButton() }
-        </div>
+        { this.Actions(backPath) }
         <PageHeader header={this.props.contractStore.contract.name} subHeader={this.props.contractStore.contract.description} />
         <div className="page-content-container">
           <div className="page-content">

--- a/src/components/pages/contracts/deployed/DeployedContractEvents.js
+++ b/src/components/pages/contracts/deployed/DeployedContractEvents.js
@@ -2,8 +2,9 @@ import React from "react";
 import Path from "path";
 import {PageHeader} from "../../../components/Page";
 import Events from "../../../components/Events";
-import {Action, AsyncComponent} from "elv-components-js";
+import {AsyncComponent} from "elv-components-js";
 import {inject, observer} from "mobx-react";
+import ActionsToolbar from "../../../components/ActionsToolbar";
 
 @inject("contractStore")
 @inject("eventsStore")
@@ -18,11 +19,17 @@ class DeployedContractEvents extends React.Component {
   PageContent() {
     return (
       <div className="page-container contracts-page-container">
-        <div className="actions-container">
-          <Action type="link" to={Path.dirname(this.props.match.url)} className="secondary">
-            Back
-          </Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <PageHeader
           header={this.props.contractStore.contract.name}
           subHeader={this.props.contractStore.contract.description}

--- a/src/components/pages/contracts/deployed/DeployedContractFundsForm.js
+++ b/src/components/pages/contracts/deployed/DeployedContractFundsForm.js
@@ -1,9 +1,10 @@
 import React from "react";
 import Path from "path";
-import {Action, Form} from "elv-components-js";
+import {Form} from "elv-components-js";
 import AsyncComponent from "../../../components/AsyncComponent";
 import {PageHeader} from "../../../components/Page";
 import {inject, observer} from "mobx-react";
+import ActionsToolbar from "../../../components/ActionsToolbar";
 
 @inject("contractStore")
 @observer
@@ -36,16 +37,24 @@ class DeployedContractFundsForm extends React.Component {
   PageContent() {
     return (
       <div className="page-container">
-        <div className="actions-container">
-          <Action type="link" className="secondary" to={Path.dirname(this.props.match.url)}>Back</Action>
-        </div>
+        <ActionsToolbar
+          showContentLookup={false}
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
         <PageHeader header={this.state.contract.name} subHeader={this.state.contract.description} />
         <Form
           legend="Transfer Contract Funds"
           redirectPath={Path.dirname(this.props.match.url)}
           cancelPath={Path.dirname(this.props.match.url)}
           OnSubmit={this.HandleSubmit}
-          className="small-form"
+          className="small-form form-page"
         >
           <div className="form-content">
             <label>Current Balance</label>

--- a/src/components/pages/events/Events.js
+++ b/src/components/pages/events/Events.js
@@ -1,14 +1,12 @@
 import React from "react";
 import Events from "../../components/Events";
-import ContentLookup from "../../components/ContentLookup";
+import ActionsToolbar from "../../components/ActionsToolbar";
 
 class EventsPage extends React.Component {
   render() {
     return (
       <div className="page-container">
-        <div className="actions-container content-lookup-actions-container">
-          <ContentLookup />
-        </div>
+        <ActionsToolbar />
         <div className="page-header-container">
           <h3 className="page-header">Blockchain Events</h3>
         </div>

--- a/src/static/stylesheets/content.scss
+++ b/src/static/stylesheets/content.scss
@@ -200,16 +200,8 @@ pre,
   }
 }
 
-.content-lookup-actions-container {
-  display: flex;
-  position: relative;
-}
-
 .content-lookup-container {
-  display: flex;
-  height: 100%;
-  position: absolute;
-  right: 0;
+  display: inline-flex;
 
   input {
     font-size: $elv-font-m;

--- a/src/static/stylesheets/defaults.scss
+++ b/src/static/stylesheets/defaults.scss
@@ -64,7 +64,7 @@
 
   .more-options-menu {
     background-color: $elv-color-bg-white;
-    border-radius: 4px;
+    border-radius: 0;
     box-shadow: 0 8px 10px 1px $elv-color-shadow-gray, 0 3px 14px 3px $elv-color-shadow-gray, 0 4px 15px 0 $elv-color-shadow-gray;
     min-width: 133px;
     opacity: 0;
@@ -106,7 +106,8 @@
         }
       }
 
-      &:hover {
+      &:hover,
+      &:focus-visible {
         background-color: $elv-color-lightergray;
       }
 

--- a/src/static/stylesheets/defaults.scss
+++ b/src/static/stylesheets/defaults.scss
@@ -30,20 +30,101 @@
   cursor: pointer;
 }
 
-.actions-wrapper {
-  .actions-container {
-    &:not(:last-child) {
-      margin-bottom: $elv-spacing-s;
-    }
-  }
-}
-
 .actions-container {
+  display: flex;
   min-height: 1.7rem;
   position: relative;
 
-  &.manage-actions {
-    margin-bottom: $elv-spacing-m;
+  .left-action-buttons,
+  .right-action-buttons {
+    display: inline-flex;
+    height: 100%;
+  }
+
+  .right-action-buttons {
+    position: absolute;
+    right: 0;
+  }
+
+  .more-options-container {
+    display: inline-block;
+
+    .more-options-text {
+      padding-right: 15px;
+      position: relative;
+
+      &::after {
+        content: "\25BC";
+        position: absolute;
+        right: 0;
+        transform: scale(1, 0.5);
+      }
+    }
+  }
+
+  .more-options-menu {
+    background-color: $elv-color-bg-white;
+    border-radius: 4px;
+    box-shadow: 0 8px 10px 1px $elv-color-shadow-gray, 0 3px 14px 3px $elv-color-shadow-gray, 0 4px 15px 0 $elv-color-shadow-gray;
+    min-width: 133px;
+    opacity: 0;
+    position: absolute;
+    transition: opacity 100ms linear;
+    visibility: hidden;
+    z-index: 999;
+
+    &--open {
+      opacity: 1;
+      visibility: visible;
+
+      .options-list {
+        display: flex;
+        flex-direction: column;
+        list-style-type: none;
+        padding: 8px 0;
+
+        .list-item {
+          align-items: center;
+          cursor: pointer;
+          display: flex;
+          height: 45px;
+          overflow: hidden;
+          padding: 0 17px;
+          position: relative;
+        }
+      }
+    }
+  }
+
+  .options-list {
+    .list-item {
+      &-danger {
+        &:not(:active):hover { // sass-lint:disable-line force-pseudo-nesting
+          background-color: $elv-color-darkergray;
+          border: 1px solid $elv-color-darkergray;
+          color: $elv-color-text-white;
+        }
+      }
+
+      &:hover {
+        background-color: $elv-color-lightergray;
+      }
+
+      &.list-divider {
+        border-top: 1px solid $elv-color-gray;
+        margin-top: 5px;
+      }
+    }
+
+    button {
+      &.list-item {
+        background: none;
+        border: 0;
+        color: $elv-color-darkgray;
+        font: inherit;
+        outline: none;
+      }
+    }
   }
 
   .-elv-button {
@@ -56,8 +137,6 @@
 
   .refresh-button {
     margin-right: $elv-spacing-xs;
-    position: absolute;
-    right: 0;
 
     svg {
       stroke: $elv-color-mediumgray;
@@ -77,6 +156,10 @@
 
 .-elv-tab-container {
   min-height: 2.35rem;
+}
+
+.form-page {
+  margin-top: $elv-spacing-m;
 }
 
 .monospace {


### PR DESCRIPTION
Componentize "actions-container" code and show two actions at a time with the remaining actions in a dropdown selector. Main actions are inline with content lookup and refresh button. Addresses area of improvement outlined in https://github.com/eluv-io/elv-fabric-browser/pull/19.

Tested actions being shown as three types of users :
- Owner
- Non-owner (edit permission)
- Non-owner (access permission)

![image](https://user-images.githubusercontent.com/91760982/145121862-eab06ca4-3b87-4498-b37b-7bb9ff0c741f.png)
