### PR TITLE
Replace metadata for owner_caps only when subtree exists

### DIFF
--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -1188,13 +1188,15 @@ const Fabric = {
       metadataSubtree: "/owner_caps"
     });
 
-    await client.ReplaceMetadata({
-      libraryId,
-      objectId,
-      writeToken,
-      metadataSubtree: "/owner_caps",
-      metadata: Object.assign(metadata, {[publicAddress]: name})
-    });
+    if(metadata) {
+      await client.ReplaceMetadata({
+        libraryId,
+        objectId,
+        writeToken,
+        metadataSubtree: "/owner_caps",
+        metadata: Object.assign(metadata, {[publicAddress]: name})
+      });
+    }
 
     return await client.FinalizeContentObject({
       libraryId,


### PR DESCRIPTION
Currently, creating a non-owner caps replaces the metadata for "/owner_caps", which throws an error when the subtree doesn't exist in the metadata.
This fix only replaces the metadata if "/owner_caps" is truthy.