### PR TITLE
Revise copy content object permission, create encryption key bug

### DIFF
--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -1196,6 +1196,14 @@ const Fabric = {
         metadataSubtree: "/owner_caps",
         metadata: Object.assign(metadata, {[publicAddress]: name})
       });
+    } else {
+      await Fabric.MergeMetadata({
+        libraryId,
+        objectId,
+        writeToken,
+        metadataSubtree: "/owner_caps",
+        metadata: {[publicAddress]: name}
+      });
     }
 
     return await client.FinalizeContentObject({

--- a/src/components/components/ActionsToolbar.js
+++ b/src/components/components/ActionsToolbar.js
@@ -45,7 +45,7 @@ const ActionsToolbar = observer(({actions, iconActions, SaveDraft, showContentLo
 
   const primaryActions = (
     visibleActions.slice(0, 2).map((action, index) => {
-      const {key, type, path, onClick, label, className} = action;
+      const {key, type, path, onClick, label, className, disabled, title} = action;
 
       return (
         <Action
@@ -54,6 +54,8 @@ const ActionsToolbar = observer(({actions, iconActions, SaveDraft, showContentLo
           to={path}
           onClick={onClick}
           className={`list-item${className ? " " + className : ""}`}
+          disabled={disabled}
+          title={title}
         >
           {label}
         </Action>
@@ -75,12 +77,13 @@ const ActionsToolbar = observer(({actions, iconActions, SaveDraft, showContentLo
           <ul className="options-list" role="menu">
             {
               visibleActions.slice(2).map((action, index) => {
-                const {key, type, path, onClick, label, className, dividerAbove} = action;
+                const {key, type, path, onClick, label, className, dividerAbove, disabled, title} = action;
 
                 return (
                   <Action
                     key={key || index}
                     className={`list-item${dividerAbove ? " list-divider" : ""}${className ? " list-item-" + className : ""}`}
+                    title={title}
                     type={type}
                     button={false}
                     to={path}
@@ -88,6 +91,7 @@ const ActionsToolbar = observer(({actions, iconActions, SaveDraft, showContentLo
                       setMoreOptionsToggle(false);
                       onClick();
                     }}
+                    disabled={disabled}
                   >
                     {label}
                   </Action>

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -12,7 +12,7 @@ import AppFrame from "../../components/AppFrame";
 import Fabric from "../../../clients/Fabric";
 import {Action, Confirm, Form, IconButton, ImageIcon, LoadingElement, Modal, Tabs, ToolTip} from "elv-components-js";
 import AsyncComponent from "../../components/AsyncComponent";
-import {AccessChargeDisplay, HashToAddress, Percentage} from "../../../utils/Helpers";
+import {AccessChargeDisplay, AddressToHash, HashToAddress, Percentage} from "../../../utils/Helpers";
 import {inject, observer} from "mobx-react";
 import ToggleSection from "../../components/ToggleSection";
 import JSONField from "../../components/JSONField";
@@ -813,6 +813,9 @@ class ContentObject extends React.Component {
   }
 
   Actions() {
+    const userCapKey = `eluv.caps.iusr${AddressToHash(this.props.objectStore.currentAccountAddress)}`;
+    const hasUserCap = !!(this.props.objectStore.object.meta && this.props.objectStore.object.meta[userCapKey]);
+
     return (
       <ActionsToolbar
         iconActions={[
@@ -859,7 +862,9 @@ class ContentObject extends React.Component {
             label: "Copy",
             type: "button",
             hidden: !this.props.objectStore.object.canEdit,
-            onClick: () => this.setState({showCopyObjectModal: true})
+            disabled: !(this.props.objectStore.object.isOwner || hasUserCap),
+            onClick: () => this.setState({showCopyObjectModal: true}),
+            title: !(this.props.objectStore.object.isOwner || hasUserCap) ? "You don't have the key" : undefined
           },
           {
             label: "Delete",

--- a/src/static/stylesheets/defaults.scss
+++ b/src/static/stylesheets/defaults.scss
@@ -97,6 +97,10 @@
   }
 
   .options-list {
+    .action-container {
+      display: flex;
+    }
+
     .list-item {
       &-danger {
         &:not(:active):hover { // sass-lint:disable-line force-pseudo-nesting
@@ -109,6 +113,16 @@
       &:hover,
       &:focus-visible {
         background-color: $elv-color-lightergray;
+      }
+
+      &:disabled {
+        color: $elv-color-mediumgray;
+        cursor: not-allowed;
+        font-weight: normal;
+
+        &:hover {
+          background: none;
+        }
       }
 
       &.list-divider {


### PR DESCRIPTION
Revise copy ability so that a user can copy an object ONLY if one of the following conditions is true:
a) they are the owner 
b) they have a non-owner encryption key

Additionally, make sure that the /owner_caps tree is created when the subtree doesn't exist in the metadata in the event of creating a non-owner cap.

Add disabled and title attributes to ActionsToolbar.

![Screen Shot 2022-01-17 at 5 10 14 PM](https://user-images.githubusercontent.com/91760982/149853953-31608d24-d7df-4a8c-9121-6ec4affc0d0b.png)

Testing:
1) An owner can copy an object and have playable encrypted videos
2) A non-owner with an encryption key can copy an object and have playable encrypted videos
