### PR TITLE
Non-owner cap form and table changes

### DIFF
--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -1173,7 +1173,11 @@ const Fabric = {
 
   CreateNonOwnerCap: async ({libraryId, objectId, publicKey, label}) => {
     const {writeToken} = await Fabric.EditContentObject({libraryId, objectId});
-    publicKey = client.utils.HashToAddress(publicKey.replace("kupk", ""), true);
+
+    if(publicKey.startsWith("kupk")) {
+      publicKey = client.utils.HashToAddress(publicKey.replace("kupk", ""), true);
+    }
+
     const publicAddress = client.utils.PublicKeyToAddress(publicKey);
 
     await client.CreateNonOwnerCap({

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -1171,14 +1171,16 @@ const Fabric = {
     };
   },
 
-  CreateNonOwnerCap: async ({libraryId, objectId, publicKey, publicAddress, name}) => {
+  CreateNonOwnerCap: async ({libraryId, objectId, publicKey, label}) => {
     const {writeToken} = await Fabric.EditContentObject({libraryId, objectId});
+    publicKey = client.utils.HashToAddress(publicKey.replace("kupk", ""), true);
+    const publicAddress = client.utils.PublicKeyToAddress(publicKey);
 
     await client.CreateNonOwnerCap({
       libraryId,
       objectId,
       publicKey,
-      publicAddress: Fabric.utils.FormatAddress(publicAddress),
+      publicAddress,
       writeToken
     });
 
@@ -1194,7 +1196,15 @@ const Fabric = {
         objectId,
         writeToken,
         metadataSubtree: "/owner_caps",
-        metadata: Object.assign(metadata, {[publicAddress]: name})
+        metadata: Object.assign(metadata, {[publicAddress]: label})
+      });
+    } else {
+      await Fabric.MergeMetadata({
+        libraryId,
+        objectId,
+        writeToken,
+        metadataSubtree: "/owner_caps",
+        metadata: {[publicAddress]: label}
       });
     }
 

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -1180,7 +1180,6 @@ const Fabric = {
       libraryId,
       objectId,
       publicKey,
-      publicAddress,
       writeToken
     });
 

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -83,8 +83,7 @@ class ContentObject extends React.Component {
       redirectIds: {},
       showNonOwnerCapManagement: false,
       newNonOwnerCapPublicKey: "",
-      newNonOwnerCapPublicAddress: "",
-      newNonOwnerCapName: "",
+      newNonOwnerCapLabel: "",
       capsVersion: false
     };
 
@@ -592,8 +591,7 @@ class ContentObject extends React.Component {
     const CloseModal = () => this.setState({
       showNonOwnerCapManagement: false,
       newNonOwnerCapPublicKey: "",
-      newNonOwnerCapPublicAddress: "",
-      newNonOwnerCapName: ""
+      newNonOwnerCapLabel: ""
     });
 
     return (
@@ -607,25 +605,17 @@ class ContentObject extends React.Component {
               libraryId: this.props.objectStore.libraryId,
               objectId: this.props.objectStore.objectId,
               publicKey: this.state.newNonOwnerCapPublicKey,
-              publicAddress: this.state.newNonOwnerCapPublicAddress,
-              name: this.state.newNonOwnerCapName
+              label: this.state.newNonOwnerCapLabel
             });
           }}
         >
           <div className="form-content">
-            <label htmlFor="userName">User Name</label>
+            <label htmlFor="label">Label</label>
             <input
-              name="userName"
+              name="label"
               required
-              placeholder="User name..."
-              onChange={event => this.setState({newNonOwnerCapName: event.target.value})}
-            />
-            <label htmlFor="publicAddress">Public Address</label>
-            <input
-              name="publicAddress"
-              required
-              placeholder="Public Address..."
-              onChange={event => this.setState({newNonOwnerCapPublicAddress: event.target.value})}
+              placeholder="Label..."
+              onChange={event => this.setState({newNonOwnerCapLabel: event.target.value})}
             />
             <label htmlFor="publicKey" className="align-top">Public Key</label>
             <textarea
@@ -667,39 +657,43 @@ class ContentObject extends React.Component {
       <div className="non-owner-caps-container">
         <ToggleSection label="Encryption Keys" toggleOpen={this.state.showNonOwnerCapManagement}>
           {addCapsButton}
-          <br />
           {
-            capKeys.length > 0 ? <div className="keys-table">
-              <div className="header-rows">
-                <div>Name</div>
-                <div>Address</div>
-                <div></div>
-              </div>
-              <div className="body-rows">
-                {capKeys.map(capAddress => {
-                  const isOwnerKey = !caps[capAddress];
+            capKeys.length > 0 ? <React.Fragment>
+              <div className="table-note">NOTE: Owner keys cannot be deleted from this table</div>
+              <div className="keys-table">
+                <div className="header-rows">
+                  <div className="table-cell">Label</div>
+                  <div className="table-cell">Type</div>
+                  <div className="table-cell">Address</div>
+                  <div className="table-cell"></div>
+                </div>
+                <div className="body-rows">
+                  {capKeys.map(capAddress => {
+                    const isOwnerKey = !caps.hasOwnProperty(capAddress);
 
-                  return (
-                    <React.Fragment key={`${capAddress}-caps-version-${this.state.capsVersion}`}>
-                      <div>{caps[capAddress] || "Owner"}</div>
-                      <div>{capAddress}</div>
-                      <div>
-                        <IconButton
-                          title="Delete this key"
-                          icon={DeleteIcon}
-                          disabled={!this.props.objectStore.object.isOwner || isOwnerKey}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            this.DeleteCap(capAddress);
-                          }}
-                          className="delete-button"
-                        />
-                      </div>
-                    </React.Fragment>
-                  );
-                })}
+                    return (
+                      <React.Fragment key={`${capAddress}-caps-version-${this.state.capsVersion}`}>
+                        <div className="table-cell">{caps[capAddress] || "Owner"}</div>
+                        <div className="table-cell">{caps[capAddress] ? "Creator" : "Owner"}</div>
+                        <div className="table-cell">{capAddress}</div>
+                        <div className="table-cell">
+                          <IconButton
+                            title="Delete this key"
+                            icon={DeleteIcon}
+                            disabled={!this.props.objectStore.object.isOwner || isOwnerKey}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              this.DeleteCap(capAddress);
+                            }}
+                            className="delete-button"
+                          />
+                        </div>
+                      </React.Fragment>
+                    );
+                  })}
+                </div>
               </div>
-            </div> : null
+            </React.Fragment>: null
           }
 
         </ToggleSection>

--- a/src/static/stylesheets/content.scss
+++ b/src/static/stylesheets/content.scss
@@ -220,10 +220,21 @@ pre,
   }
 }
 
-.keys-table {
-  max-width: 700px;
-  padding-left: 150px;
+.non-owner-caps-container {
+  .table-note,
+  .keys-table {
+    max-width: 1000px;
+    padding-left: 150px;
+  }
 
+  .table-note {
+    font-size: .9rem;
+    padding-bottom: 15px;
+    padding-top: 15px;
+  }
+}
+
+.keys-table {
   .header-rows {
     background-color: $elv-color-lightgray;
     font-weight: 500;
@@ -235,14 +246,22 @@ pre,
     align-items: center;
     display: grid;
     gap: 10px; // sass-lint:disable-line no-misspelled-properties
-    grid-template-columns: 1fr 2fr 50px;
+    grid-template-columns: 2fr 140px 4fr 50px;
     padding: 5px 10px;
 
     .delete-button {
       display: block;
       height: 20px;
       margin: auto;
+
+      &:disabled {
+        cursor: not-allowed;
+      }
     }
+  }
+
+  .table-cell {
+    padding: 3px;
   }
 }
 

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -633,13 +633,12 @@ class ObjectStore {
   });
 
   @action.bound
-  CreateNonOwnerCap = flow(function * ({libraryId, objectId, publicKey, publicAddress, name}) {
+  CreateNonOwnerCap = flow(function * ({libraryId, objectId, publicKey, label}) {
     yield Fabric.CreateNonOwnerCap({
       libraryId,
       objectId,
       publicKey,
-      publicAddress,
-      name
+      label
     });
 
     this.objects[objectId].meta = yield Fabric.GetContentObjectMetadata({


### PR DESCRIPTION
Address the following changes in regards to non-owner caps:
- Change "name" row header and form input to "label"
- Add "type" table column to display whether the key is an Owner/Creator type
- Convert multiformat public key when passing to CreateNonOwnerCap
- Remove "public address" from form
- Table styling changes

Tested

- Create non-owner key for new object
- Create non-owner key for object with existing keys
- Converting public key to address returns expected value
- Converting address back to public key returns expected value


![Screen Shot 2022-02-08 at 10 16 08 AM](https://user-images.githubusercontent.com/91760982/153061548-f20c5e27-be2c-4604-9359-c3c681abe911.png)
![Screen Shot 2022-02-08 at 11 31 30 AM](https://user-images.githubusercontent.com/91760982/153061633-84e08a91-968d-4ec5-b639-729b0eec34b4.png)

