### PR TITLE
Add tenant ID field to ContentLibraryForm

### DIFF
--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -59,6 +59,10 @@ const Fabric = {
     return `ikms${Fabric.utils.AddressToHash(await client.DefaultKMSAddress())}`;
   },
 
+  DefaultTenantId: async () => {
+    return await client.userProfileClient.TenantId();
+  },
+
   /* Access Groups */
 
   CreateAccessGroup: async ({name, description, metadata={}}) => {

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -361,7 +361,7 @@ const Fabric = {
     return FormatAddress(await client.ContentLibraryOwner({libraryId}));
   },
 
-  CreateContentLibrary: async ({name, description, publicMetadata={}, privateMetadata={}, kmsId}) => {
+  CreateContentLibrary: async ({name, description, publicMetadata={}, privateMetadata={}, kmsId, tenantId}) => {
     return await client.CreateContentLibrary({
       name,
       description,
@@ -369,7 +369,8 @@ const Fabric = {
         ...privateMetadata,
         public: publicMetadata
       },
-      kmsId
+      kmsId,
+      tenantId
     });
   },
 

--- a/src/components/pages/content/ContentLibraryForm.js
+++ b/src/components/pages/content/ContentLibraryForm.js
@@ -55,7 +55,8 @@ class ContentLibraryForm extends React.Component {
       publicMetadata: this.state.publicMetadata,
       privateMetadata: this.state.privateMetadata,
       image: this.state.imageSelection,
-      kmsId: this.state.kmsId
+      kmsId: this.state.kmsId,
+      tenantId: this.state.tenantId
     });
 
     this.setState({

--- a/src/components/pages/content/ContentLibraryForm.js
+++ b/src/components/pages/content/ContentLibraryForm.js
@@ -20,6 +20,7 @@ class ContentLibraryForm extends React.Component {
       privateMetadata: "{}",
       kmsId: "",
       imageSelection: "",
+      tenantId: ""
     };
 
     this.PageContent = this.PageContent.bind(this);
@@ -114,6 +115,9 @@ class ContentLibraryForm extends React.Component {
 
                 { this.Image() }
 
+                <label htmlFor="tenantId">Tenant ID</label>
+                <input name="tenantId" type="text" value={this.state.tenantId} required={true} onChange={this.HandleInputChange} />
+
                 <label className="align-top" htmlFor="description">Description</label>
                 <textarea name="description" value={this.state.description} onChange={this.HandleInputChange} />
 
@@ -150,7 +154,8 @@ class ContentLibraryForm extends React.Component {
           async () => {
             if(this.state.createForm) {
               this.setState({
-                kmsId: await this.props.libraryStore.DefaultKMSId() || ""
+                kmsId: await this.props.libraryStore.DefaultKMSId() || "",
+                tenantId: await this.props.libraryStore.DefaultTenantId() || ""
               });
             } else {
               await this.props.libraryStore.ContentLibrary({

--- a/src/stores/Library.js
+++ b/src/stores/Library.js
@@ -24,6 +24,10 @@ class LibraryStore {
     return await Fabric.DefaultKMSId();
   }
 
+  async DefaultTenantId() {
+    return await Fabric.DefaultTenantId();
+  }
+
   @action.bound
   ListContentLibraries = flow(function * ({params}) {
     let { libraries, count } = yield Cancelable(

--- a/src/stores/Library.js
+++ b/src/stores/Library.js
@@ -64,7 +64,7 @@ class LibraryStore {
   });
 
   @action.bound
-  CreateContentLibrary = flow(function * ({name, description, publicMetadata, privateMetadata, image, kmsId}) {
+  CreateContentLibrary = flow(function * ({name, description, publicMetadata, privateMetadata, image, kmsId, tenantId}) {
     try {
       privateMetadata = ParseInputJson(privateMetadata);
     } catch(error) {
@@ -85,7 +85,8 @@ class LibraryStore {
       description,
       publicMetadata,
       privateMetadata,
-      kmsId
+      kmsId,
+      tenantId
     });
 
     if(image) {


### PR DESCRIPTION
Add required tenant ID field to the ContentLibraryForm, which sets tenantId in CreateContentLibrary.

The default value will set from the user tenantId metadata.

![image](https://user-images.githubusercontent.com/91760982/157102060-3e16a2ef-5bbc-4765-8dc4-59753a03f039.png)

