### PR TITLE
Add ingest page

### DIFF
--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -336,6 +336,12 @@ class ContentLibrary extends React.Component {
             type: "button",
             hidden: this.props.libraryStore.library.isContentSpaceLibrary || !(this.props.libraryStore.library.isOwner && this.props.libraryStore.library.canContribute),
             onClick: () => this.setState({showCopyObjectModal: true})
+          },
+          {
+            label: "Create Media Object",
+            type: "link",
+            path: UrlJoin(this.props.match.url, "ingest"),
+            hidden: this.props.libraryStore.library.privateMeta && !this.props.libraryStore.library.privateMeta.abr
           }
         ]}
       />

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -861,6 +861,12 @@ class ContentObject extends React.Component {
             title: !(this.props.objectStore.object.isOwner || hasUserCap) ? "You don't have the key" : undefined
           },
           {
+            label: "Convert to Media Object",
+            type: "link",
+            path: UrlJoin(this.props.match.url, "ingest"),
+            hidden: (this.props.libraryStore.library.privateMeta && !this.props.libraryStore.library.privateMeta.abr) || (this.props.objectStore.object.meta && this.props.objectStore.object.meta.abr_mezzanine)
+          },
+          {
             label: "Delete",
             type: "button",
             hidden: this.props.objectStore.object.isContentLibraryObject || !this.props.objectStore.object.canEdit || !this.props.objectStore.object.isOwner,

--- a/src/components/pages/ingest/Ingest.js
+++ b/src/components/pages/ingest/Ingest.js
@@ -1,0 +1,40 @@
+import React from "react";
+import ActionsToolbar from "../../components/ActionsToolbar";
+import AppFrame from "../../components/AppFrame";
+import Path from "path";
+
+class Ingest extends React.Component {
+
+  render() {
+    const queryParams = {
+      libraryId: this.props.match.params.libraryId
+    };
+
+    return (
+      <div className="page-container">
+        <ActionsToolbar
+          actions={[
+            {
+              label: "Back",
+              type: "link",
+              path: Path.dirname(this.props.match.url),
+              className: "secondary"
+            }
+          ]}
+        />
+
+        <div className="page-content-container form-page">
+          <AppFrame
+            className="form-frame"
+            appUrl={EluvioConfiguration["fabricBrowserApps"]["ingest-media"]}
+            queryParams={queryParams}
+            onComplete={() => this.setState({pageVersion: this.state.pageVersion + 1})}
+            onCancel={() => this.setState({deleted: true})}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Ingest;

--- a/src/components/pages/ingest/Ingest.js
+++ b/src/components/pages/ingest/Ingest.js
@@ -10,6 +10,10 @@ class Ingest extends React.Component {
       libraryId: this.props.match.params.libraryId
     };
 
+    if(this.props.match.params.objectId) {
+      queryParams.objectId = this.props.match.params.objectId;
+    }
+
     return (
       <div className="page-container">
         <ActionsToolbar

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -149,6 +149,8 @@ class Router extends React.Component {
           <WatchedRoute exact path="/content/:libraryId/:objectId" component={ContentObjectPage}/>
           <WatchedRoute exact path="/content-types/:objectId" component={ContentObjectPage}/>
 
+          <WatchedRoute exact path="/content/:libraryId/:objectId/ingest" component={Ingest} />
+
           <WatchedRoute exact path="/content/:libraryId/:objectId/edit" component={ContentObjectFormPage}/>
           <WatchedRoute exact path="/content-types/:objectId/edit" component={ContentTypeFormPage} />
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -39,6 +39,7 @@ import DeployedContractEventsPage from "../components/pages/contracts/deployed/D
 
 import EventsPage from "../components/pages/events/Events";
 import { Redirect, withRouter } from "react-router";
+import Ingest from "../components/pages/ingest/Ingest";
 
 @inject("notificationStore")
 @inject("routeStore")
@@ -139,6 +140,8 @@ class Router extends React.Component {
           <WatchedRoute exact path="/content/:libraryId/edit" component={ContentLibraryFormPage}/>
 
           <WatchedRoute exact path="/content/:libraryId/types" component={ContentLibraryTypesFormPage}/>
+
+          <WatchedRoute exact path="/content/:libraryId/ingest" component={Ingest} />
 
           <WatchedRoute exact path="/content/:libraryId/create" component={ContentObjectFormPage}/>
           <WatchedRoute exact path="/content-types/create" component={ContentTypeFormPage} />


### PR DESCRIPTION
Support ingesting media within a Library and Content Object.

Library page > More Options > Create Media Object
Library > Content Object > More Options > Convert to Media Object

Works with [elv-ingest](https://github.com/eluv-io/elv-ingest).

Library page
![image](https://user-images.githubusercontent.com/91760982/168132056-2b4a3286-d868-4d45-b964-60d889525075.png)

Object page
![image](https://user-images.githubusercontent.com/91760982/170566088-3d27a794-1213-4520-b7b2-2687c6ae4780.png)


![image](https://user-images.githubusercontent.com/91760982/170565783-5cbf6b01-e5b0-49e3-9d3f-f58696121cbc.png)


## Usage

The library must be configured with a default abr profile and mezzanine content type via the metadata, formatted as such:
```
abr: {
  default_profile: {} // object: abr profile may be copied from elv-client-js/utilities/example_files
  mez_content_type: "" // string: content type version hash or title
}
```
You should now be able to see the Media Object button within More Options. Please note, the button is visible on objects that haven't yet been ingested.
