### PR TITLE
Disable objects without permission when copying

### DIFF
--- a/src/components/components/ContentBrowser.js
+++ b/src/components/components/ContentBrowser.js
@@ -128,7 +128,7 @@ const VersionBrowser = observer(({libraryId, objectId, Select}) => {
   );
 });
 
-const ObjectBrowser = observer(({libraryId, Select}) => {
+const ObjectBrowser = observer(({libraryId, Select, DisableCallback, disableTitle}) => {
   const [filter, setFilter] = useState("");
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -142,7 +142,13 @@ const ObjectBrowser = observer(({libraryId, Select}) => {
         key={`object-browser-${libraryId}-${page}-${filter}`}
         Load={async () => {
           await contentStore.LoadLibraries();
-          const { objects, paging } = await contentStore.LoadObjects({libraryId, filter, page});
+          const { objects, paging } = await contentStore.LoadObjects({
+            libraryId,
+            filter,
+            page,
+            SetDisabled: DisableCallback,
+            disableTitle
+          });
 
           setPage(page);
           setTotalPages(paging.pages);
@@ -150,13 +156,18 @@ const ObjectBrowser = observer(({libraryId, Select}) => {
         }}
       >
         <div className="list content-list content-list-objects">
-          {
-            (objects || [])
-              .map(({objectId, versionHash, name, playable, title}) =>
-                <button title={title} onClick={() => Select({name, playable, objectId, versionHash})} className="list-item content-list-item" key={`object-${objectId}`}>
-                  { name }
-                </button>
-              )
+          {(objects || [])
+            .map(({objectId, versionHash, name, playable, title, disabled}) =>
+              <button
+                title={title}
+                onClick={() => Select({name, playable, objectId, versionHash})}
+                className="list-item content-list-item"
+                key={`object-${objectId}`}
+                disabled={disabled}
+              >
+                {name}
+              </button>
+            )
           }
         </div>
       </AsyncComponent>
@@ -197,7 +208,7 @@ const LibraryBrowser = observer(({Select}) => {
   );
 });
 
-const ContentBrowser = observer(({header, Select, Close, requireVersion=false, requireObject=true}) => {
+const ContentBrowser = observer(({header, Select, Close, requireVersion=false, requireObject=true, DisableObjectCallback, disableObjectTitle}) => {
   const [libraryId, setLibraryId] = useState("");
   const [libraryName, setLibraryName] = useState("");
   const [objectId, setObjectId] = useState("");
@@ -296,6 +307,8 @@ const ContentBrowser = observer(({header, Select, Close, requireVersion=false, r
         { libraryId && !objectId ?
           <ObjectBrowser
             libraryId={libraryId}
+            DisableCallback={DisableObjectCallback}
+            disableTitle={disableObjectTitle}
             Select={({name, playable, objectId, versionHash}) => {
               if(requireVersion) {
                 setObjectName(name);

--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -407,6 +407,15 @@ class ContentLibrary extends React.Component {
             <ContentBrowserModal
               Close={() =>  this.setState({showCopyObjectModal: false})}
               Select={selection => this.CopyObject(selection)}
+              DisableObjectCallback={async ({objectId, libraryId}) => {
+                const hasPermission = await this.props.objectStore.CopyObjectPermission({
+                  libraryId,
+                  objectId
+                });
+
+                return !hasPermission;
+              }}
+              disableObjectTitle="Ownership or a user cap required"
             /> : null
         }
       </div>

--- a/src/static/stylesheets/content_browser.scss
+++ b/src/static/stylesheets/content_browser.scss
@@ -72,6 +72,10 @@
       &:not(.list-header):not(:disabled):hover { // sass-lint:disable-line force-pseudo-nesting
         border-left: 3px solid $elv-color-mediumblue;
       }
+
+      &:disabled {
+        cursor: not-allowed;
+      }
     }
 
     &-item {

--- a/src/static/stylesheets/defaults.scss
+++ b/src/static/stylesheets/defaults.scss
@@ -60,6 +60,12 @@
         transform: scale(1, 0.5);
       }
     }
+
+    .-elv-button {
+      &:focus {
+        overflow: hidden;
+      }
+    }
   }
 
   .more-options-menu {

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -232,7 +232,7 @@ class ObjectStore {
     );
     const isOwner = EqualAddress(owner, yield Fabric.CurrentAccountAddress());
 
-    if(isOwner) return true;
+    if(isOwner) { return true; }
 
     // Determine presence of user cap
     try {


### PR DESCRIPTION
When copying a content object, disable objects that do not meet one of the following requirements:
1. The current user is an owner of the object
2. The current user has a user cap on the object

![Screen Shot 2022-07-15 at 2 00 28 PM](https://user-images.githubusercontent.com/91760982/179310443-d52274c4-d670-424a-8a51-a57c9f01c4ba.png)
