### PR TITLE
Do not show display tab for objects sans offerings

### DIFF
--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -911,7 +911,12 @@ class ContentObject extends React.Component {
       ["Files", "files"]
     ];
 
-    if(!this.props.objectStore.object.isContentType && this.state.displayAppUrl) {
+    if(
+      !this.props.objectStore.object.isContentType &&
+      this.state.displayAppUrl &&
+      this.props.objectStore.object.meta &&
+      this.props.objectStore.object.meta.hasOwnProperty("offerings")
+    ) {
       tabOptions.unshift(["Display", "display"]);
     }
 


### PR DESCRIPTION
Don't show Display tab for content objects with no offerings.
Relates to #43 