### PR TITLE
Clear address visibility cache in Permission call

### DIFF
--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -674,7 +674,7 @@ const Fabric = {
       // Only normal objects have status and access charge
       tasks = tasks.concat([
         Fabric.GetAccessInfo({objectId}), // accessInfo
-        client.Permission({objectId}), // permission
+        client.Permission({objectId, clearCache: true}), // permission
         client.CallContractMethod({ // kmsAddress
           contractAddress: client.utils.HashToAddress(objectId),
           methodName: "addressKMS"


### PR DESCRIPTION
Use `clearCache` flag on `Permission` call to update the Visibility, and ultimately, the permission in Fabric Browser.

Relates to #41 
Requires https://github.com/eluv-io/elv-client-js/pull/181