### PR TITLE
Add indexer prefix, root, query fields

### DIFF
--- a/src/components/components/ContentBrowser.js
+++ b/src/components/components/ContentBrowser.js
@@ -208,7 +208,16 @@ const LibraryBrowser = observer(({Select}) => {
   );
 });
 
-const ContentBrowser = observer(({header, Select, Close, requireVersion=false, requireObject=true, DisableObjectCallback, disableObjectTitle}) => {
+const ContentBrowser = observer(({
+  header,
+  Select,
+  Close,
+  requireVersion=false,
+  requireObject=true,
+  DisableObjectCallback,
+  disableObjectTitle,
+  confirmMessageCallback
+}) => {
   const [libraryId, setLibraryId] = useState("");
   const [libraryName, setLibraryName] = useState("");
   const [objectId, setObjectId] = useState("");
@@ -218,21 +227,26 @@ const ContentBrowser = observer(({header, Select, Close, requireVersion=false, r
 
   const FinalSelect = async (args) => {
     setLoading(true);
-    await Confirm({
-      message: `Are you sure you want to copy ${args.name} into ${args.libraryName}?`,
-      onConfirm: async () => {
-        await Select(args);
-        Close();
-      },
-      onCancel: () => {
-        setLibraryId(undefined);
-        setLibraryName(undefined);
-        setObjectId(undefined);
-        setObjectName("");
-        setObjectPlayable(false);
-        setLoading(false);
-      }
-    });
+    if(confirmMessageCallback) {
+      await Confirm({
+        message: confirmMessageCallback({name: args.name, libraryName: args.libraryName}),
+        onConfirm: async () => {
+          await Select(args);
+          Close();
+        },
+        onCancel: () => {
+          setLibraryId(undefined);
+          setLibraryName(undefined);
+          setObjectId(undefined);
+          setObjectName("");
+          setObjectPlayable(false);
+          setLoading(false);
+        }
+      });
+    } else {
+      await Select(args);
+      Close();
+    }
   };
 
   return (

--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -423,6 +423,7 @@ class ContentLibrary extends React.Component {
                 return !hasPermission;
               }}
               disableObjectTitle="Ownership or a user cap required"
+              confirmMessageCallback={({name, libraryName}) => `Are you sure you want to copy ${name} into ${libraryName}?`}
             /> : null
         }
       </div>

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -1058,6 +1058,7 @@ class ContentObject extends React.Component {
               Select={(selection) => this.CopyObject(selection)}
               requireObject={false}
               header="Select a library"
+              confirmMessageCallback={({name, libraryName}) => `Are you sure you want to copy ${name} into ${libraryName}?`}
             /> : null
         }
       </div>

--- a/src/components/pages/content/ContentObjectForm.js
+++ b/src/components/pages/content/ContentObjectForm.js
@@ -319,12 +319,15 @@ class ContentObjectForm extends React.Component {
               const privateMetadata = JSON.stringify(meta, null, 2);
 
               this.setState({
-                showIndexerTab: object &&
+                showIndexerTab: !!(
+                  object &&
                   object.typeInfo &&
                   object.typeInfo.latestType &&
                   object.typeInfo.latestType.meta &&
                   object.typeInfo.latestType.meta.public &&
-                  object.typeInfo.latestType.meta.public.title_configuration
+                  object.typeInfo.latestType.meta.public.title_configuration &&
+                  object.typeInfo.latestType.meta.public.title_configuration.show_indexer_settings
+                )
               });
 
               const manageAppUrl = object.manageAppUrl || (object.typeInfo || {}).manageAppUrl;

--- a/src/static/stylesheets/defaults.scss
+++ b/src/static/stylesheets/defaults.scss
@@ -192,3 +192,15 @@
 .monospace {
   font-family: $elv-font-monospace;
 }
+
+.hint-tooltip {
+  &.-elv-tooltip {
+    font-size: $elv-font-s;
+    max-width: 100rem;
+    padding: 14px 10px;
+  }
+}
+
+select {
+  background-color: $elv-color-white;
+}

--- a/src/static/stylesheets/indexer_form.scss
+++ b/src/static/stylesheets/indexer_form.scss
@@ -12,6 +12,7 @@
     justify-content: space-around;
     left: 0;
     margin-bottom: 2rem;
+    padding: 0 1rem;
     position: sticky;
     top: 0;
     width: 100%;
@@ -21,6 +22,7 @@
       font-size: 1.4rem;
       font-weight: 400;
       text-align: center;
+      width: 100%;
     }
   }
 
@@ -29,6 +31,17 @@
 
     .indexer-info-container {
       width: 100%;
+
+      .form-separator {
+        background: $elv-color-lightgray;
+        height: 1px;
+        margin: 2.5rem auto;
+        width: 90%;
+      }
+
+      .object-selection-field {
+        margin: 1.5rem 0;
+      }
     }
 
     .-elv-input {
@@ -43,8 +56,44 @@
       }
 
       &.-elv-input {
-        font-size: 0.9rem;
+        font-size: 0.8rem;
         grid-template-columns: 8rem 1fr;
+        margin-bottom: 0.25rem;
+
+        & > input {
+          border: 1px solid $elv-color-gray;
+          max-width: 35rem;
+          min-width: 35rem;
+        }
+
+        &.object-selection-container {
+          align-items: flex-start;
+          width: 35rem;
+        }
+
+        .multi-input {
+          align-items: flex-start;
+          max-width: 35rem;
+          min-width: 35rem;
+
+          label {
+            margin-top: 0.5rem;
+          }
+
+          button {
+            align-items: center;
+            display: flex;
+            justify-content: center;
+            margin: 0;
+          }
+        }
+
+        .multi-input-item {
+          align-items: center;
+          display: grid;
+          grid-template-columns: 1fr 2.5rem;
+          margin-bottom: 0.5rem;
+        }
       }
 
       &.checkbox-container {
@@ -63,9 +112,55 @@
           }
         }
       }
+
+      .hint-label {
+        display: flex;
+
+        svg {
+          margin-left: 0.5rem;
+          max-height: 1rem;
+          max-width: 1rem;
+          min-height: 1rem;
+          min-width: 1rem;
+          stroke: $elv-color-text-light;
+        }
+      }
+
+      label {
+        color: $elv-color-text-light;
+      }
+
+      .selected-item {
+        align-items: center;
+        border: 1px solid $elv-color-lightgray;
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 0.5rem;
+        margin-right: 1rem;
+        padding: 0.5rem;
+        word-break: break-all;
+      }
+
+      .object-selection-actions {
+        align-items: center;
+        display: flex;
+
+        button,
+        a {
+          &:not(:last-child) {
+            margin-right: 0.5rem;
+          }
+        }
+
+        svg {
+          height: 1.25rem;
+          width: 1.25rem;
+        }
+      }
     }
 
     .list-field-container {
+      align-items: flex-start;
       width: max-content;
 
       .info-list-icon {

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -316,37 +316,42 @@ class ObjectStore {
     });
   });
 
-  @action.bound
-  EditAndFinalizeMetadata = flow(function * ({
+@action.bound
+ReplaceMetadata = flow(function * ({
+  libraryId,
+  objectId,
+  writeToken,
+  metadataSubtree,
+  metadata
+}) {
+  yield Fabric.ReplaceMetadata({
     libraryId,
     objectId,
-    metadataSubtree="/",
-    metadata,
-    commitMessage,
-    awaitCommitConfirmation
+    writeToken,
+    metadataSubtree,
+    metadata
+  });
+});
+
+  @action.bound
+  EditAndFinalizeContentObject = flow(function * ({
+    libraryId,
+    objectId,
+    callback,
+    options={},
+    commitMessage="",
+    publish=true,
+    awaitCommitConfirmation=true
   }) {
-    const {writeToken} = yield Fabric.EditContentObject({
-      libraryId,
-      objectId
-    });
-
-    yield Fabric.ReplaceMetadata({
+    yield Fabric.client.EditAndFinalizeContentObject({
       libraryId,
       objectId,
-      writeToken,
-      metadataSubtree,
-      metadata
-    });
-
-    yield Fabric.FinalizeContentObject({
-      libraryId,
-      objectId,
-      writeToken,
+      callback,
+      options,
       commitMessage,
+      publish,
       awaitCommitConfirmation
     });
-
-    return objectId;
   });
 
   @action.bound


### PR DESCRIPTION
Add missing fields for indexer configuration:
- Query suffix
- Document prefix
- Root
- Multiple fields for `paths`

Fix issue with show_indexer_settings not properly showing/hiding Indexer tab.

Relates to #32 