### PR TITLE
Update LRO status retrieval to work with metadata path `/lro_draft`

### DIFF
--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -1,6 +1,6 @@
 import { FrameClient } from "@eluvio/elv-client-js/src/FrameClient";
 import UrlJoin from "url-join";
-import {EqualAddress, FormatAddress} from "../utils/Helpers";
+import {EqualAddress, FormatAddress, LROStatus} from "../utils/Helpers";
 
 let client = new FrameClient({
   target: window.parent,
@@ -701,46 +701,12 @@ const Fabric = {
     const kmsId = kmsAddress ? `ikms${client.utils.AddressToHash(kmsAddress)}` : undefined;
 
     // Non-cacheable (contract / LRO status)
-    const lroStatus = await (async () => {
-      // New convention "/lro_draft" - check first
-      try {
-        if(object.meta.lro_draft) {
-          const offeringKey = object.meta.lro_draft.offering;
-          const status = await client.LROStatus({libraryId, objectId});
-          return [{
-            offeringKey,
-            status
-          }];
-        }
-      } catch(error) {
-        // eslint-disable-next-line no-console
-        console.error("Failed to load LRO status:");
-        // eslint-disable-next-line no-console
-        console.error(error);
-      }
-
-      // Old convention "/lro_draft_*"
-      return (await Promise.all(
-        Object.keys(object.meta)
-          .filter(key => key.startsWith("lro_draft_"))
-          .map(async lroKey => {
-            try {
-              const offeringKey = lroKey.replace(/^lro_draft_/, "");
-              const status = await client.LROStatus({libraryId, objectId, offeringKey});
-              return {
-                offeringKey,
-                status
-              };
-            } catch(error) {
-              // eslint-disable-next-line no-console
-              console.error("Failed to load LRO status:");
-              // eslint-disable-next-line no-console
-              console.error(error);
-            }
-          })
-      )).filter(status => status);
+    const lroStatus = await LROStatus({
+      client,
+      libraryId,
+      objectId,
+      metadata: object.meta
     });
-
 
     // Not able to get owner name
     let ownerName;


### PR DESCRIPTION
Support metadata path `/lro_draft` (no offering key suffix) and give that path precedence. 

`/lro_draft_*` paths still checked as fallback to maintain backwards compatibility.

For upcoming ingest API update I would like to switch to always using `/lro_draft` to store draft info, regardless of what the offering key is.

(For all current use cases, mezzanines only have one offering ingest active at any one time, and the offering key is stored within the reference)
e.g.:
```
{
    "node": "http://localhost:8008",
    "offering": "default",
    "write_token": "tqw__HSWbfMeb18NzTMqXdbsweAv673uXt3vVhqn5p5PgQdaWtPR9pEKJzviLvEnnscsoNX5tVpNGA9QCCnqye4p"
  }
```


Tested locally for backwards compatibility with release version of elv-client-js. Continues to show progress / status for ingests that use the present `lro_draft_OFFERING_KEY` convention




