### PR TITLE
Show display tab if displayAppUrl OR has offerings

### DIFF
--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -916,9 +916,9 @@ class ContentObject extends React.Component {
 
     if(
       !this.props.objectStore.object.isContentType &&
-      this.state.displayAppUrl &&
-      this.props.objectStore.object.meta &&
-      this.props.objectStore.object.meta.hasOwnProperty("offerings")
+      this.state.displayAppUrl ||
+      (this.props.objectStore.object.meta &&
+      this.props.objectStore.object.meta.hasOwnProperty("offerings"))
     ) {
       tabOptions.unshift(["Display", "display"]);
     }


### PR DESCRIPTION
Display tab should show if there is a displayAppUrl in the metadata OR if the metadata has `offerings`.