### PR TITLE
Fix large file uploads; use File object in place of arrayBuffer

### DIFF
--- a/src/utils/Files.js
+++ b/src/utils/Files.js
@@ -23,7 +23,8 @@ export const FileInfo = async (path, fileList, noData=false, trimDirectory) => {
 
   return await Promise.all(
     Array.from(fileList).map(async file => {
-      const data = noData ? undefined : file;
+      const isFileType = file instanceof File;
+      const data = noData ? undefined : isFileType ? file : await new Response(file).arrayBuffer();
       let filePath = file.overrideName || file.webkitRelativePath || file.name;
       if(trimDirectory) {
         filePath = filePath.split("/")[1];

--- a/src/utils/Files.js
+++ b/src/utils/Files.js
@@ -23,7 +23,7 @@ export const FileInfo = async (path, fileList, noData=false, trimDirectory) => {
 
   return await Promise.all(
     Array.from(fileList).map(async file => {
-      const data = noData ? undefined : await new Response(file).arrayBuffer();
+      const data = noData ? undefined : file;
       let filePath = file.overrideName || file.webkitRelativePath || file.name;
       if(trimDirectory) {
         filePath = filePath.split("/")[1];


### PR DESCRIPTION
Use File object instead of array buffer in UploadFiles() `fileInfo`. This is consistent with what is implemented in the ingest app and works.