### PR TITLE
Ignore container when generating diff, separate diff logic

### DIFF
--- a/src/components/components/Diff.js
+++ b/src/components/components/Diff.js
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import AsyncComponent from "./AsyncComponent";
 import {observer} from "mobx-react";
 import {objectStore} from "../../stores";
@@ -8,48 +8,60 @@ import {IconButton} from "elv-components-js";
 import UpArrow from "../../static/icons/arrow-up-circle.svg";
 import DownArrow from "../../static/icons/arrow-down-circle.svg";
 
-const Diff = observer(({json, diff}) => {
-  const previousVersionIndex = ((objectStore.object.versions || []).findIndex(version => version === json.hash)) + 1;
-  const previousVersionHash = objectStore.object.versions[previousVersionIndex];
-  const [totalDiffCount, setTotalDiffCount] = useState(0);
+const GetDiffParts = ({json, diff}) => {
+  typeof json === "string" ? json = JSON.parse(json || "{}") : json;
+  const diffArray = diffJson(diff, json);
+  let diffIndex = 0;
+
+  const parts = diffArray.map((part, i) => {
+    const consecutiveAddedPart = part.added ? !!(diffArray[i - 1].removed) : false;
+    const isDiff = (part.added || part.removed) && !consecutiveAddedPart;
+
+    if((part.added || part.removed) && part.value.includes("\"container\": \"hq__")) {
+      return;
+    }
+
+    const element = (
+      <p
+        key={i}
+        id={`${isDiff ? `difference-${diffIndex}` : ""}`}
+        className={part.added ? "part-addition" : part.removed ? "part-deletion" : ""}
+      >
+        {part.value}
+      </p>
+    );
+
+    if(isDiff) { diffIndex++; }
+
+    return element;
+  });
+
+  return {parts, diffIndex};
+};
+
+const RenderDiff = ({parts}) => {
+  if(!parts) { return null; }
+
+  return <pre className="diff-block">{parts}</pre>;
+};
+
+const DiffActions = ({totalDiffCount}) => {
   const [currentDiffInView, setCurrentDiffInView] = useState(0);
 
-  const RenderDiff = () => {
-    typeof json.meta === "string" ? json.meta = JSON.parse(json.meta || "{}") : json.meta;
-
-    const diffArray = diffJson(diff || objectStore.versions[previousVersionHash].meta, json.meta);
-
-    let diffIndex = 0;
-    const parts = diffArray.map((part, i) => {
-      const consecutiveAddedPart = part.added ? !!(diffArray[i - 1].removed) : false;
-      const isDiff = (part.added || part.removed) && !consecutiveAddedPart;
-
-      const element = (
-        <p
-          key={i}
-          id={`${isDiff ? `difference-${diffIndex}` : ""}`}
-          className={part.added ? "part-addition" : part.removed ? "part-deletion" : ""}
-        >
-          {part.value}
-        </p>
-      );
-
-      if(isDiff) { diffIndex++; }
-
-      return element;
-    });
-
-    setTotalDiffCount(diffIndex);
-
-    return <pre className="diff-block">{parts}</pre>;
-  };
+  useEffect(() => {
+    setTimeout(() => {
+      ScrollToDifference(0);
+    }, 100);
+  }, []);
 
   const ScrollToDifference = (newIndex) => {
     setCurrentDiffInView(newIndex);
-    document.getElementById(`difference-${newIndex}`).scrollIntoView();
+    const element = document.getElementById(`difference-${newIndex}`);
+
+    if(element) { element.scrollIntoView(); }
   };
 
-  const diffActions = (
+  return (
     <div className="actions-container">
       <IconButton
         icon={UpArrow}
@@ -65,20 +77,51 @@ const Diff = observer(({json, diff}) => {
       />
     </div>
   );
+};
+
+const Diff = observer(({json, diff}) => {
+  const previousVersionIndex = ((objectStore.object.versions || []).findIndex(version => version === json.hash)) + 1;
+  const previousVersionHash = objectStore.object.versions[previousVersionIndex];
+  const [totalDiffCount, setTotalDiffCount] = useState(0);
+  const [parts, setParts] = useState([]);
+
+  if(diff) {
+    const {parts, diffIndex} = GetDiffParts({
+      json: json.meta,
+      diff
+    });
+
+    setParts(parts);
+    setTotalDiffCount(diffIndex);
+  }
 
   return (
     <div className="diff-container">
       {
         diff ?
-          RenderDiff() :
+          <RenderDiff parts={parts} /> :
           <AsyncComponent
             Load={
-              async () => await objectStore.ContentObjectVersion({versionHash: previousVersionHash})
+              async () => {
+                await objectStore.ContentObjectVersion({versionHash: previousVersionHash});
+                const {parts, diffIndex} = GetDiffParts({
+                  json: json.meta,
+                  diff: objectStore.versions[previousVersionHash].meta
+                });
+
+                setParts(parts);
+                setTotalDiffCount(diffIndex);
+              }
             }
-            render={() => RenderDiff()}
+            render={() => (
+              <RenderDiff parts={parts} />
+            )}
           />
       }
-      { diffActions }
+      {
+        parts.length > 0 &&
+        <DiffActions totalDiffCount={totalDiffCount} />
+      }
     </div>
   );
 });


### PR DESCRIPTION
Enhance Diff logic. Separate functions so they're not nested, creating a new reference on each render. The `jsdiff` library offers no support for ignoring specified keys so add condition that excludes `"container": "hq__` from being returned in the added/removed changes.