### PR TITLE
Add json editor to object metadata fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "browser-solc": "^1.0.0",
         "diff": "^5.0.0",
         "elv-components-js": "git+https://github.com/eluv-io/elv-components-js.git",
+        "jsoneditor": "^9.10.2",
         "luxon": "^1.25.0",
         "mobx": "^5.13.1",
         "mobx-react": "^6.1.3",
@@ -2368,6 +2369,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@sphinxxxx/color-conversion": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@sphinxxxx/color-conversion/-/color-conversion-2.2.2.tgz",
+      "integrity": "sha512-XExJS3cLqgrmNBIP3bBw6+1oQ1ksGjFh0+oClDKFYpCCqx/hlqwWO5KO/S63fzUo67SxI9dMrF0y5T/Ey7h8Zw=="
+    },
     "node_modules/@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -2600,6 +2606,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/ace-builds": {
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.23.4.tgz",
+      "integrity": "sha512-a4hKAT2T7KNUQC4LQPW2peuoEsZmLYTn4Dwjkh26A3Z+fQ8/fA2JZNs3V6CqvivhbyMQXQJD1u/0qTCoSS6deA=="
     },
     "node_modules/acorn": {
       "version": "6.4.1",
@@ -11119,6 +11130,19 @@
         "node": ">= 4"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+    },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/js-base64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
@@ -11189,6 +11213,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "node_modules/json-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg=="
+    },
     "node_modules/json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -11221,6 +11250,22 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsoneditor": {
+      "version": "9.10.2",
+      "resolved": "https://registry.npmjs.org/jsoneditor/-/jsoneditor-9.10.2.tgz",
+      "integrity": "sha512-sT9U8T9MB7We5uyCnofugqYPJtQ5rPJngFlvpdtyFTFKFjOMnlWE1jVhFwjTXwGBoFeiLS+S6rVuhIhJ35Jutw==",
+      "dependencies": {
+        "ace-builds": "^1.20.0",
+        "ajv": "^6.12.6",
+        "javascript-natural-sort": "^0.7.1",
+        "jmespath": "^0.16.0",
+        "json-source-map": "^0.6.1",
+        "jsonrepair": "^3.1.0",
+        "mobius1-selectr": "^2.4.13",
+        "picomodal": "^3.0.0",
+        "vanilla-picker": "^2.12.1"
       }
     },
     "node_modules/jsonfile": {
@@ -11256,6 +11301,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsonrepair": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.2.0.tgz",
+      "integrity": "sha512-6eHBc2z5vipym4S8rzTcCXQBLWpkSzi9bk7I3xTdUxRzXyYvfjoVZzJ97N4C/9vcKI9NgNp3slPwHufDr0rFYw==",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -12145,6 +12198,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mobius1-selectr": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/mobius1-selectr/-/mobius1-selectr-2.4.13.tgz",
+      "integrity": "sha512-Mk9qDrvU44UUL0EBhbAA1phfQZ7aMZPjwtL7wkpiBzGh8dETGqfsh50mWoX9EkjDlkONlErWXArHCKfoxVg0Bw=="
     },
     "node_modules/mobx": {
       "version": "5.15.0",
@@ -13413,6 +13471,11 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/picomodal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/picomodal/-/picomodal-3.0.0.tgz",
+      "integrity": "sha512-FoR3TDfuLlqUvcEeK5ifpKSVVns6B4BQvc8SDF6THVMuadya6LLtji0QgUDSStw0ZR2J7I6UGi5V2V23rnPWTw=="
     },
     "node_modules/pify": {
       "version": "4.0.1",
@@ -18474,6 +18537,14 @@
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
       "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
+    "node_modules/vanilla-picker": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.12.1.tgz",
+      "integrity": "sha512-2qrEP9VYylKXbyzXKsbu2dferBTvqnlsr29XjHwFE+/MEp0VNj6oEUESLDtKZ7DWzGdSv1x/+ujqFZF+KsO3cg==",
+      "dependencies": {
+        "@sphinxxxx/color-conversion": "^2.2.2"
+      }
+    },
     "node_modules/varint": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
@@ -22298,6 +22369,11 @@
         }
       }
     },
+    "@sphinxxxx/color-conversion": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@sphinxxxx/color-conversion/-/color-conversion-2.2.2.tgz",
+      "integrity": "sha512-XExJS3cLqgrmNBIP3bBw6+1oQ1ksGjFh0+oClDKFYpCCqx/hlqwWO5KO/S63fzUo67SxI9dMrF0y5T/Ey7h8Zw=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -22527,6 +22603,11 @@
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
+    },
+    "ace-builds": {
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.23.4.tgz",
+      "integrity": "sha512-a4hKAT2T7KNUQC4LQPW2peuoEsZmLYTn4Dwjkh26A3Z+fQ8/fA2JZNs3V6CqvivhbyMQXQJD1u/0qTCoSS6deA=="
     },
     "acorn": {
       "version": "6.4.1",
@@ -29589,6 +29670,16 @@
         "is-object": "^1.0.1"
       }
     },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+    },
+    "jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
+    },
     "js-base64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
@@ -29647,6 +29738,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg=="
+    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -29678,6 +29774,22 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsoneditor": {
+      "version": "9.10.2",
+      "resolved": "https://registry.npmjs.org/jsoneditor/-/jsoneditor-9.10.2.tgz",
+      "integrity": "sha512-sT9U8T9MB7We5uyCnofugqYPJtQ5rPJngFlvpdtyFTFKFjOMnlWE1jVhFwjTXwGBoFeiLS+S6rVuhIhJ35Jutw==",
+      "requires": {
+        "ace-builds": "^1.20.0",
+        "ajv": "^6.12.6",
+        "javascript-natural-sort": "^0.7.1",
+        "jmespath": "^0.16.0",
+        "json-source-map": "^0.6.1",
+        "jsonrepair": "^3.1.0",
+        "mobius1-selectr": "^2.4.13",
+        "picomodal": "^3.0.0",
+        "vanilla-picker": "^2.12.1"
+      }
+    },
     "jsonfile": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
@@ -29703,6 +29815,11 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "dev": true
+    },
+    "jsonrepair": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.2.0.tgz",
+      "integrity": "sha512-6eHBc2z5vipym4S8rzTcCXQBLWpkSzi9bk7I3xTdUxRzXyYvfjoVZzJ97N4C/9vcKI9NgNp3slPwHufDr0rFYw=="
     },
     "jsx-ast-utils": {
       "version": "2.2.3",
@@ -30444,6 +30561,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "mobius1-selectr": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/mobius1-selectr/-/mobius1-selectr-2.4.13.tgz",
+      "integrity": "sha512-Mk9qDrvU44UUL0EBhbAA1phfQZ7aMZPjwtL7wkpiBzGh8dETGqfsh50mWoX9EkjDlkONlErWXArHCKfoxVg0Bw=="
     },
     "mobx": {
       "version": "5.15.0",
@@ -31451,6 +31573,11 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "devOptional": true
+    },
+    "picomodal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/picomodal/-/picomodal-3.0.0.tgz",
+      "integrity": "sha512-FoR3TDfuLlqUvcEeK5ifpKSVVns6B4BQvc8SDF6THVMuadya6LLtji0QgUDSStw0ZR2J7I6UGi5V2V23rnPWTw=="
     },
     "pify": {
       "version": "4.0.1",
@@ -35593,6 +35720,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
       "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
+    },
+    "vanilla-picker": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.12.1.tgz",
+      "integrity": "sha512-2qrEP9VYylKXbyzXKsbu2dferBTvqnlsr29XjHwFE+/MEp0VNj6oEUESLDtKZ7DWzGdSv1x/+ujqFZF+KsO3cg==",
+      "requires": {
+        "@sphinxxxx/color-conversion": "^2.2.2"
+      }
     },
     "varint": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "browser-solc": "^1.0.0",
     "diff": "^5.0.0",
     "elv-components-js": "git+https://github.com/eluv-io/elv-components-js.git",
+    "jsoneditor": "^9.10.2",
     "luxon": "^1.25.0",
     "mobx": "^5.13.1",
     "mobx-react": "^6.1.3",

--- a/src/components/components/JSONEditorField.js
+++ b/src/components/components/JSONEditorField.js
@@ -1,0 +1,60 @@
+import React, {useEffect, useRef, useState} from "react";
+import JSONEditor from "jsoneditor";
+import "jsoneditor/dist/jsoneditor.css";
+import "../../static/ace-themes/eluvio-theme";
+
+const JSONEditorField = ({json, OnChange}) => {
+  const ref = useRef(json);
+  const [errorMessage, setErrorMessage] = useState("");
+  let jsonEditor;
+
+  useEffect(() => {
+    const options = {
+      mode: "code",
+      onChangeText: () => {
+        try {
+          jsonEditor.get();
+          OnChange(jsonEditor.get());
+        } catch(error) {
+          // Invalid JSON. Don't print to console so as not to clog with errors on each keystroke
+        }
+      },
+      mainMenuBar: false,
+      onValidationError: errors => {
+        if(
+          !errors ||
+          !Array.isArray(errors) ||
+          errors.length < 1
+        ) {
+          setErrorMessage("");
+        } else {
+          const concatMessages = errors
+            .map(error => error.message)
+            .join("\n");
+          setErrorMessage(concatMessages);
+        }
+      }
+    };
+
+    jsonEditor = new JSONEditor(ref.current, options);
+    jsonEditor.set(json);
+    jsonEditor.aceEditor.setTheme("ace/theme/eluvio");
+
+    return () => {
+      if(jsonEditor) {
+        jsonEditor.destroy();
+      }
+    };
+  }, []);
+
+  return (
+    <div>
+      <div className="json-editor-container" ref={ref}></div>
+      {
+        errorMessage && <div className="json-editor-error-message">{errorMessage}</div>
+      }
+    </div>
+  );
+};
+
+export default JSONEditorField;

--- a/src/components/pages/content/ContentObjectForm.js
+++ b/src/components/pages/content/ContentObjectForm.js
@@ -1,7 +1,7 @@
 import React from "react";
 import UrlJoin from "url-join";
 import Path from "path";
-import {BrowseWidget, Form, JsonInput, LoadingElement, Tabs} from "elv-components-js";
+import {BrowseWidget, Form, LoadingElement, Tabs} from "elv-components-js";
 import {inject, observer} from "mobx-react";
 import AsyncComponent from "../../components/AsyncComponent";
 import {Redirect} from "react-router";
@@ -9,6 +9,7 @@ import {toJS} from "mobx";
 import Fabric from "../../../clients/Fabric";
 import AppFrame from "../../components/AppFrame";
 import ActionsToolbar from "../../components/ActionsToolbar";
+import JSONEditorField from "../../components/JSONEditorField";
 import SearchConfiguration from "./SearchConfiguration";
 
 @inject("libraryStore")
@@ -24,8 +25,8 @@ class ContentObjectForm extends React.Component {
       createForm: !props.objectStore.objectId,
       name: "",
       description: "",
-      publicMetadata: "{}",
-      privateMetadata: "{}",
+      publicMetadata: {},
+      privateMetadata: {},
       type: "",
       types: {},
       imageSelection: "",
@@ -61,7 +62,7 @@ class ContentObjectForm extends React.Component {
       objectId: this.props.objectStore.objectId,
       type: this.state.type,
       name: this.state.name,
-      description: this.state.description,
+      description: this.state.description || this.state.publicMetadata.description,
       publicMetadata: this.state.publicMetadata,
       privateMetadata: this.state.privateMetadata,
       image: this.state.imageSelection,
@@ -145,17 +146,17 @@ class ContentObjectForm extends React.Component {
           <textarea name="description" value={this.state.description} onChange={this.HandleInputChange} />
 
           <label className="align-top" htmlFor="publicMetadata">Public Metadata</label>
-          <JsonInput
+          <JSONEditorField
             name="publicMetadata"
-            value={this.state.publicMetadata}
-            onChange={this.HandleInputChange}
+            json={this.state.publicMetadata}
+            OnChange={value => this.setState({publicMetadata: value})}
           />
 
           <label className="align-top" htmlFor="privateMetadata">Private Metadata</label>
-          <JsonInput
+          <JSONEditorField
+            json={this.state.privateMetadata}
             name="privateMetadata"
-            value={this.state.privateMetadata}
-            onChange={this.HandleInputChange}
+            OnChange={value => this.setState({privateMetadata: value})}
           />
 
           <label htmlFor="commitMessage">Commit Message</label>
@@ -314,9 +315,9 @@ class ContentObjectForm extends React.Component {
             if(this.props.objectStore.objectId) {
               const object = this.props.objectStore.object;
               const meta = {...toJS(object.meta)};
-              const publicMetadata = JSON.stringify(meta.public || {}, null, 2);
+              const publicMetadata = meta.public || {};
               delete meta.public;
-              const privateMetadata = JSON.stringify(meta, null, 2);
+              const privateMetadata = meta;
 
               this.setState({
                 showIndexerTab: !!(

--- a/src/static/ace-themes/eluvio-theme.js
+++ b/src/static/ace-themes/eluvio-theme.js
@@ -1,0 +1,134 @@
+/* eslint-disable no-unused-vars */
+window.ace.define("ace/theme/eluvio", ["require", "exports", "module", "ace/lib/dom"], (acequire, exports, module) => {
+  exports.isDark = false;
+  exports.cssClass = "ace-eluvio";
+  exports.cssText = `
+  .ace-eluvio .ace_gutter {
+  background: #e8e8e8;
+  color: #AAA;
+}
+
+.ace-eluvio  {
+  background: #fff;
+  color: #000;
+}
+
+.ace-eluvio .ace_keyword {
+  font-weight: bold;
+}
+
+.ace-eluvio .ace_string {
+  color: rgba(155, 81, 224, 1);
+}
+
+.ace-eluvio .ace_variable.ace_class {
+  color: teal;
+}
+
+.ace-eluvio .ace_constant.ace_numeric {
+  color: rgba(45, 156, 219, 1);
+}
+
+.ace-eluvio .ace_constant.ace_buildin {
+  color: #0086B3;
+}
+
+.ace-eluvio .ace_support.ace_function {
+  color: #0086B3;
+}
+
+.ace-eluvio .ace_comment {
+  color: #998;
+  font-style: italic;
+}
+
+.ace-eluvio .ace_variable.ace_language  {
+  color: #0086B3;
+}
+
+.ace-eluvio .ace_paren {
+  font-weight: bold;
+}
+
+.ace-eluvio .ace_boolean {
+  font-weight: bold;
+}
+
+.ace-eluvio .ace_string.ace_regexp {
+  color: #009926;
+  font-weight: normal;
+}
+
+.ace-eluvio .ace_variable.ace_instance {
+  color: teal;
+}
+
+.ace-eluvio .ace_constant.ace_language {
+  font-weight: bold;
+}
+
+.ace-eluvio .ace_cursor {
+  color: black;
+}
+
+.ace-eluvio.ace_focus .ace_marker-layer .ace_active-line {
+  background: rgb(255, 255, 204);
+}
+.ace-eluvio .ace_marker-layer .ace_active-line {
+  background: rgb(245, 245, 245);
+}
+
+.ace-eluvio .ace_marker-layer .ace_selection {
+  background: rgb(181, 213, 255);
+}
+
+.ace-eluvio.ace_multiselect .ace_selection.ace_start {
+  box-shadow: 0 0 3px 0px white;
+}
+/* bold keywords cause cursor issues for some fonts */
+/* this disables bold style for editor and keeps for static highlighter */
+.ace-eluvio.ace_nobold .ace_line > span {
+  font-weight: normal !important;
+}
+
+.ace-eluvio .ace_marker-layer .ace_step {
+  background: rgb(252, 255, 0);
+}
+
+.ace-eluvio .ace_marker-layer .ace_stack {
+  background: rgb(164, 229, 101);
+}
+
+.ace-eluvio .ace_marker-layer .ace_bracket {
+  margin: -1px 0 0 -1px;
+  border: 1px solid rgb(192, 192, 192);
+}
+
+.ace-eluvio .ace_gutter-active-line {
+  background-color : rgba(0, 0, 0, 0.07);
+}
+
+.ace-eluvio .ace_marker-layer .ace_selected-word {
+  background: rgb(250, 250, 255);
+  border: 1px solid rgb(200, 200, 250);
+}
+
+.ace-eluvio .ace_invisible {
+  color: #BFBFBF
+}
+
+.ace-eluvio .ace_print-margin {
+  width: 1px;
+  background: #e8e8e8;
+}
+
+.ace-eluvio .ace_indent-guide {
+  background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAE0lEQVQImWP4////f4bLly//BwAmVgd1/w11/gAAAABJRU5ErkJggg==") right repeat-y;
+}
+
+.ace-eluvio .ace_indent-guide-active {
+  background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAIGNIUk0AAHolAACAgwAA+f8AAIDpAAB1MAAA6mAAADqYAAAXb5JfxUYAAAAZSURBVHjaYvj///9/hivKyv8BAAAA//8DACLqBhbvk+/eAAAAAElFTkSuQmCC") right repeat-y;
+}`;
+  const dom = acequire("../lib/dom");
+  dom.importCssString(exports.cssText, exports.cssClass, false);
+});

--- a/src/static/stylesheets/forms.scss
+++ b/src/static/stylesheets/forms.scss
@@ -136,3 +136,18 @@ button {
     }
   }
 }
+
+.json-editor-container {
+  height: 50rem;
+  width: 100%;
+
+  .jsoneditor {
+    border-color: $elv-color-gray;
+  }
+}
+
+.json-editor-error-message {
+  background-color: $elv-diff-delete-color;
+  margin: 1rem 0;
+  padding: 1rem;
+}

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -2,7 +2,6 @@ import Fabric from "../clients/Fabric";
 import {action, computed, flow, observable} from "mobx";
 import {DownloadFromUrl, FileInfo} from "../utils/Files";
 import UrlJoin from "url-join";
-import {ParseInputJson} from "elv-components-js";
 import Path from "path";
 import {AddressToHash, EqualAddress} from "../utils/Helpers";
 const Fetch = typeof fetch !== "undefined" ? fetch : require("node-fetch").default;
@@ -93,13 +92,6 @@ class ObjectStore {
     image,
     commitMessage
   }) {
-    try {
-      privateMetadata = ParseInputJson(privateMetadata);
-      publicMetadata = ParseInputJson(publicMetadata);
-    } catch(error) {
-      throw `Invalid Metadata: ${error.message}`;
-    }
-
     const create = !objectId;
 
     let editResponse;


### PR DESCRIPTION
Add editor view to content object metadata fields using `jsoneditor`, which validates and formats.
![image](https://github.com/eluv-io/elv-fabric-browser/assets/91760982/10133f7b-d246-46c8-8221-a4deaa5fe5e3)

Error state:
![image](https://github.com/eluv-io/elv-fabric-browser/assets/91760982/3636959f-b798-403a-9389-5bddd739c4b2)
