### PR TITLE
Fix diff container to remove new line from regex

### DIFF
--- a/src/components/components/Diff.js
+++ b/src/components/components/Diff.js
@@ -15,7 +15,7 @@ const GetDiffParts = ({json, diff}) => {
 
   const parts = diffArray.map((part, i) => {
     const consecutiveAddedPart = part.added ? !!(diffArray[i - 1].removed) : false;
-    const containerPattern = /^.+\"container\":.\"hq__[a-zA-Z0-9_]*\"\n/;
+    const containerPattern = /^.+\"container\":.\"hq__[a-zA-Z0-9_]*\"/;
     const isDiff = (part.added || part.removed) && !consecutiveAddedPart && !containerPattern.test(part.value);
 
     if((part.added || part.removed) && containerPattern.test(part.value)) {


### PR DESCRIPTION
Regex is not flexible enough when looking at "container": "hq__" key/values in the diff. Remove the new line from the expression.