### PR TITLE
Add ability to generate embed url for media objects

### DIFF
--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -84,7 +84,8 @@ class ContentObject extends React.Component {
       showNonOwnerCapManagement: false,
       newNonOwnerCapPublicKey: "",
       newNonOwnerCapLabel: "",
-      capsVersion: false
+      capsVersion: false,
+      embedUrl: ""
     };
 
     this.PageContent = this.PageContent.bind(this);
@@ -705,6 +706,38 @@ class ContentObject extends React.Component {
     );
   }
 
+  EmbedUrlSection = () => {
+    if(
+      this.props.objectStore.object.isContentType ||
+      !(this.props.objectStore.object.meta &&
+      this.props.objectStore.object.meta.hasOwnProperty("offerings"))
+    ) {
+      return null;
+    }
+
+    return (
+      <>
+        <LabelledField label="Embed URL" copyValue={this.state.embedUrl || ""}>
+          {
+            this.state.embedUrl ?
+              this.state.embedUrl :
+              <Action
+                type="button"
+                className="secondary"
+                onClick={async () => {
+                  const embedUrl = await this.props.objectStore.GenerateEmbedUrl();
+                  this.setState({embedUrl});
+                }}
+              >
+                Generate Embed URL
+              </Action>
+          }
+        </LabelledField>
+        <br />
+      </>
+    );
+  };
+
   ObjectInfo() {
     const object = this.props.objectStore.object;
 
@@ -799,6 +832,8 @@ class ContentObject extends React.Component {
         <br />
 
         { this.OwnerCapsSection() }
+
+        { this.EmbedUrlSection() }
 
         { this.ObjectVersion({versionHash: object.hash, latestVersion: true}) }
 

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -970,6 +970,27 @@ MergeMetadata = flow(function * ({
       versionHash
     });
   });
+
+  @action.bound
+  GenerateEmbedUrl = flow(function * () {
+    const networkInfo = yield Fabric.client.NetworkInfo();
+    let embedUrl = new URL("https://embed.v3.contentfabric.io");
+    const networkName = networkInfo.name === "demov3" ? "demo" : (networkInfo.name === "test" && networkInfo.id === 955205) ? "testv4" : networkInfo.name;
+
+    const token = yield Fabric.client.CreateSignedToken({
+      objectId: this.object.id,
+      duration: 100 * 24 * 60 * 60 * 1000 // milliseconds
+    });
+
+    embedUrl.searchParams.set("p", "");
+    embedUrl.searchParams.set("ap", "");
+    embedUrl.searchParams.set("net", networkName);
+    embedUrl.searchParams.set("ct", "s");
+    embedUrl.searchParams.set("oid", this.object.id);
+    embedUrl.searchParams.set("ath", token);
+
+    return embedUrl.toString();
+  });
 }
 
 export default ObjectStore;


### PR DESCRIPTION
Add ability to generate an embed URL for playable content objects.
The button visibility follows the same logic as when the Display tab shows (when the metadata includes `offerings`).

This change will also be added to Media Ingest and Video Editor.


![generate-embed-url-frowser](https://github.com/eluv-io/elv-fabric-browser/assets/91760982/9ed9d1cc-6daa-40a4-aeac-71c4f10fe5d2)
