### PR TITLE
Change library group permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "3.0.24",
       "license": "MIT",
       "dependencies": {
-        "@eluvio/elv-client-js": "^4.0.63",
+        "@eluvio/elv-client-js": "git+https://github.com/eluv-io/elv-client-js.git#issue-80",
         "bignumber.js": "^8.1.1",
         "browser-cancelable-events": "^1.0.1",
         "browser-solc": "^1.0.0",
@@ -2019,9 +2019,9 @@
       }
     },
     "node_modules/@eluvio/elv-client-js": {
-      "version": "4.0.63",
-      "resolved": "https://registry.npmjs.org/@eluvio/elv-client-js/-/elv-client-js-4.0.63.tgz",
-      "integrity": "sha512-v6QMrqX75B3Js9tig1dnHsyCUCfMhVw/eGEjnDbWdwVj1l/WYYwwnlbWpoWP7/lxWiiDjxSTkVMKJjYymW6O/g==",
+      "version": "4.0.50",
+      "resolved": "git+ssh://git@github.com/eluv-io/elv-client-js.git#4cc77ab2fc196ae87feae2d452e1849feaaa1dbc",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
         "@eluvio/crypto": "^1.1.1",
@@ -23320,9 +23320,8 @@
       }
     },
     "@eluvio/elv-client-js": {
-      "version": "4.0.63",
-      "resolved": "https://registry.npmjs.org/@eluvio/elv-client-js/-/elv-client-js-4.0.63.tgz",
-      "integrity": "sha512-v6QMrqX75B3Js9tig1dnHsyCUCfMhVw/eGEjnDbWdwVj1l/WYYwwnlbWpoWP7/lxWiiDjxSTkVMKJjYymW6O/g==",
+      "version": "git+ssh://git@github.com/eluv-io/elv-client-js.git#4cc77ab2fc196ae87feae2d452e1849feaaa1dbc",
+      "from": "@eluvio/elv-client-js@git+https://github.com/eluv-io/elv-client-js.git#issue-80",
       "requires": {
         "@babel/runtime": "^7.8.4",
         "@eluvio/crypto": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "3.0.24",
       "license": "MIT",
       "dependencies": {
-        "@eluvio/elv-client-js": "git+https://github.com/eluv-io/elv-client-js.git#issue-80",
+        "@eluvio/elv-client-js": "^4.0.66",
         "bignumber.js": "^8.1.1",
         "browser-cancelable-events": "^1.0.1",
         "browser-solc": "^1.0.0",
@@ -2019,9 +2019,9 @@
       }
     },
     "node_modules/@eluvio/elv-client-js": {
-      "version": "4.0.50",
-      "resolved": "git+ssh://git@github.com/eluv-io/elv-client-js.git#4cc77ab2fc196ae87feae2d452e1849feaaa1dbc",
-      "license": "MIT",
+      "version": "4.0.66",
+      "resolved": "https://registry.npmjs.org/@eluvio/elv-client-js/-/elv-client-js-4.0.66.tgz",
+      "integrity": "sha512-aWl2/x9eCNCNRwCgHYkfBZD4LStJZi0i4CKNJd4W7e6d3j2zCXRgMbED8SH36Rp0tyrUV5ASWvW2tuJsNKU2aw==",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
         "@eluvio/crypto": "^1.1.1",
@@ -23320,8 +23320,9 @@
       }
     },
     "@eluvio/elv-client-js": {
-      "version": "git+ssh://git@github.com/eluv-io/elv-client-js.git#4cc77ab2fc196ae87feae2d452e1849feaaa1dbc",
-      "from": "@eluvio/elv-client-js@git+https://github.com/eluv-io/elv-client-js.git#issue-80",
+      "version": "4.0.66",
+      "resolved": "https://registry.npmjs.org/@eluvio/elv-client-js/-/elv-client-js-4.0.66.tgz",
+      "integrity": "sha512-aWl2/x9eCNCNRwCgHYkfBZD4LStJZi0i4CKNJd4W7e6d3j2zCXRgMbED8SH36Rp0tyrUV5ASWvW2tuJsNKU2aw==",
       "requires": {
         "@babel/runtime": "^7.8.4",
         "@eluvio/crypto": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "last 2 versions"
   ],
   "dependencies": {
-    "@eluvio/elv-client-js": "^4.0.63",
+    "@eluvio/elv-client-js": "git+https://github.com/eluv-io/elv-client-js.git#issue-80",
     "bignumber.js": "^8.1.1",
     "browser-cancelable-events": "^1.0.1",
     "browser-solc": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "last 2 versions"
   ],
   "dependencies": {
-    "@eluvio/elv-client-js": "git+https://github.com/eluv-io/elv-client-js.git#issue-80",
+    "@eluvio/elv-client-js": "^4.0.66",
     "bignumber.js": "^8.1.1",
     "browser-cancelable-events": "^1.0.1",
     "browser-solc": "^1.0.0",

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -527,6 +527,26 @@ const Fabric = {
     });
   },
 
+  SetContentLibraryRights: async ({libraryId, address, type="SEE", access}) => {
+    // access - 1 add | 0 revoke
+    const typeMap = {
+      "SEE": 0,
+      "ACCESS": 1,
+      "EDIT": 2
+    };
+    const accessType = typeMap[type];
+
+    await client.CallContractMethodAndWait({
+      contractAddress: client.utils.HashToAddress(libraryId),
+      methodName: "setRights",
+      methodArgs: [
+        FormatAddress(address),
+        accessType,
+        access
+      ]
+    });
+  },
+
   RemoveContentLibraryGroup: async ({libraryId, address, groupType}) => {
     const event = await client.CallContractMethodAndWait({
       contractAddress: client.utils.HashToAddress(libraryId),

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -483,7 +483,7 @@ const Fabric = {
       methodArgs: [
         FormatAddress(address),
         2, // TYPE_SEE = 0; TYPE_ACCESS = 1; TYPE_EDIT = 2
-        1 // CATEGORY_GROUP = 2
+        1 // adding
       ]
     });
 
@@ -511,8 +511,8 @@ const Fabric = {
       methodName: "setRights",
       methodArgs: [
         FormatAddress(address),
-        0, // TYPE_SEE = 0; TYPE_ACCESS = 1; TYPE_EDIT = 2
-        1 // CATEGORY_GROUP = 2
+        2, // TYPE_SEE = 0; TYPE_ACCESS = 1; TYPE_EDIT = 2
+        0 // revoking
       ]
     });
 

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -714,6 +714,7 @@ const Fabric = {
     const isContentLibraryObject = client.utils.EqualHash(libraryId, objectId);
     const isContentType = libraryId === Fabric.contentSpaceLibraryId && !isContentLibraryObject;
     const isNormalObject = !isContentLibraryObject && !isContentType;
+    const {isV3} = await client.ContractInfo({id: objectId});
 
     const latestVersionHash = await client.LatestVersionHash({objectId});
 
@@ -875,7 +876,8 @@ const Fabric = {
       isContentLibraryObject,
       isContentType,
       isNormalObject,
-      accessType
+      accessType,
+      isV3
     };
   },
 

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -504,6 +504,17 @@ const Fabric = {
     }
   },
 
+  CheckLibraryCanContribute: async ({libraryId}) => {
+    const contractAddress = client.utils.HashToAddress(libraryId);
+    return client.CallContractMethod({
+      contractAddress,
+      methodName: "canContribute",
+      methodArgs: [
+        FormatAddress(Fabric.currentAccountAddress)
+      ]
+    });
+  },
+
   RemoveContentLibraryManagerGroup: async ({libraryId, address}) => {
     const contractAddress = client.utils.HashToAddress(libraryId);
     await client.CallContractMethodAndWait({

--- a/src/components/pages/access_groups/AccessGroup.js
+++ b/src/components/pages/access_groups/AccessGroup.js
@@ -283,7 +283,10 @@ class AccessGroup extends React.Component {
         <ContentObjectGroups
           currentPage="accessGroup"
           showGroupPermissionsButton={this.props.groupStore.accessGroup.isManager || this.props.groupStore.accessGroup.isOwner}
-          LoadGroupPermissions={() => {}}
+          LoadGroupPermissions={async () => {
+            await this.props.groupStore.AccessGroupGroupPermissions({contractAddress: this.props.groupStore.contractAddress});
+            await this.props.groupStore.SetInheritedGroupAccess();
+          }}
         />
       );
     } else {

--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -109,9 +109,9 @@ class ContentLibrary extends React.Component {
             </div>
             <Tabs
               options={[
-                ["Viewers", "accessor"],
-                ["Contributors", "contributor"],
-                ["Reviewers", "reviewer"]
+                ["View", "accessor"],
+                ["Contribute", "contributor"],
+                ["Manage", "reviewer"]
               ]}
               className="secondary"
               selected={this.state.groupsView}

--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -74,11 +74,11 @@ class ContentLibrary extends React.Component {
     );
   }
 
-  async RemoveAccessGroupMember({groupAddress}) {
+  async RemoveAccessGroupPermission({groupAddress}) {
     await Confirm({
-      message: "Are you sure you want to remove this group from the library?",
+      message: "Are you sure you want to remove this group's permissions on this library?",
       onConfirm: async () => {
-        await this.props.libraryStore.RemoveContentLibraryGroup({
+        await this.props.libraryStore.RemoveContentLibraryGroupPermission({
           libraryId: this.props.libraryStore.libraryId,
           groupAddress,
           type: this.state.groupsView
@@ -109,7 +109,7 @@ class ContentLibrary extends React.Component {
             <IconButton
               icon={RemoveIcon}
               label="Remove Access Group"
-              onClick={async () => this.RemoveAccessGroupMember({groupAddress: address})}
+              onClick={async () => this.RemoveAccessGroupPermission({groupAddress: address})}
             >
               Remove
             </IconButton>

--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -6,7 +6,7 @@ import ContentIcon from "../../../static/icons/content.svg";
 import {LabelledField} from "../../components/LabelledField";
 import ClippedText from "../../components/ClippedText";
 import {PageHeader} from "../../components/Page";
-import {Action, Tabs} from "elv-components-js";
+import {Action, Confirm, IconButton, Tabs} from "elv-components-js";
 import AsyncComponent from "../../components/AsyncComponent";
 
 import Listing from "../../components/Listing";
@@ -18,6 +18,7 @@ import ContentLibraryGroupForm from "./ContentLibraryGroupForm";
 import {ContentBrowserModal} from "../../components/ContentBrowser";
 import {Redirect} from "react-router";
 import ActionsToolbar from "../../components/ActionsToolbar";
+import RemoveIcon from "../../../static/icons/close.svg";
 
 @inject("libraryStore")
 @inject("groupStore")
@@ -73,6 +74,23 @@ class ContentLibrary extends React.Component {
     );
   }
 
+  async RemoveAccessGroupMember({groupAddress}) {
+    await Confirm({
+      message: "Are you sure you want to remove this group from the library?",
+      onConfirm: async () => {
+        await this.props.libraryStore.RemoveContentLibraryGroup({
+          libraryId: this.props.libraryStore.libraryId,
+          groupAddress,
+          type: this.state.groupsView
+        });
+      }
+    });
+
+    if(this.state.listingRef) {
+      this.state.listingRef.Load();
+    }
+  }
+
   AccessGroups() {
     const groups = this.props.libraryStore.library[`${this.state.groupsView}Groups`];
 
@@ -86,7 +104,17 @@ class ContentLibrary extends React.Component {
         sortKey: (group.name || "zz").toLowerCase(),
         title: group.name || address,
         description: group.description,
-        link: UrlJoin("/access-groups", address)
+        status: (
+          <div className="listing-action-icon">
+            <IconButton
+              icon={RemoveIcon}
+              label="Remove Access Group"
+              onClick={async () => this.RemoveAccessGroupMember({groupAddress: address})}
+            >
+              Remove
+            </IconButton>
+          </div>
+        )
       };
     });
 
@@ -118,11 +146,16 @@ class ContentLibrary extends React.Component {
               onChange={(value) => this.setState({groupsView: value})}
             />
             <Listing
+              ref={ref => {
+                if(!this.state.listingRef) {
+                  this.setState({listingRef: ref});
+                }
+              }}
               key={`library-access-group-listing-${this.state.groupsView}`}
               className="compact"
               pageId="LibraryAccessGroups"
               noIcon={true}
-              noStatus={true}
+              noLink={true}
               paginate={true}
               count={this.props.libraryStore.library[`${type}GroupsCount`] || 0}
               LoadContent={async ({params}) => {

--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -352,7 +352,7 @@ class ContentLibrary extends React.Component {
           {
             label: "Manage",
             type: "link",
-            hidden: !this.props.libraryStore.library.isOwner,
+            hidden: !(this.props.libraryStore.library.isOwner || this.props.libraryStore.library.isManager),
             path: UrlJoin(this.props.match.url, "edit"),
           },
           {
@@ -370,7 +370,7 @@ class ContentLibrary extends React.Component {
           {
             label: "Create From Existing",
             type: "button",
-            hidden: this.props.libraryStore.library.isContentSpaceLibrary || !(this.props.libraryStore.library.isOwner && this.props.libraryStore.library.canContribute),
+            hidden: this.props.libraryStore.library.isContentSpaceLibrary || !(this.props.libraryStore.library.isManager && this.props.libraryStore.library.canContribute),
             onClick: () => this.setState({showCopyObjectModal: true})
           }
         ]}

--- a/src/components/pages/content/ContentLibrary.js
+++ b/src/components/pages/content/ContentLibrary.js
@@ -130,16 +130,19 @@ class ContentLibrary extends React.Component {
         }}
         render={() => (
           <React.Fragment>
-            <div>
-              <Action onClick={() => this.setState({showGroupForm: true})}>
-                Manage Group Permissions
-              </Action>
-            </div>
+            {
+              this.props.libraryStore.library.isManager &&
+              <div>
+                <Action onClick={() => this.setState({showGroupForm: true})}>
+                  Manage Group Permissions
+                </Action>
+              </div>
+            }
             <Tabs
               options={[
                 ["View", "accessor"],
                 ["Contribute", "contributor"],
-                ["Manage", "reviewer"]
+                ["Manage", "manage"]
               ]}
               className="secondary"
               selected={this.state.groupsView}

--- a/src/components/pages/content/ContentLibraryGroupForm.js
+++ b/src/components/pages/content/ContentLibraryGroupForm.js
@@ -13,9 +13,7 @@ class ContentLibraryGroupForm extends React.Component {
 
     this.state = {
       groupAddress: "",
-      accessor: false,
-      reviewer: false,
-      contributor: false
+      selectedPermission: ""
     };
 
     this.PageContent = this.PageContent.bind(this);
@@ -28,9 +26,9 @@ class ContentLibraryGroupForm extends React.Component {
 
     this.setState({
       groupAddress: event.target.value,
-      accessor: !!permissions.accessor,
-      contributor: !!permissions.contributor,
-      reviewer: !!permissions.reviewer
+      selectedPermission: (
+        permissions.reviewer ? "MANAGE" : permissions.contributor ? "CONTRIBUTE" : permissions.accessor ? "VIEW" : ""
+      )
     });
   }
 
@@ -38,9 +36,9 @@ class ContentLibraryGroupForm extends React.Component {
     await this.props.libraryStore.UpdateContentLibraryGroup({
       libraryId: this.props.libraryStore.libraryId,
       groupAddress: this.state.groupAddress,
-      accessor: this.state.accessor,
-      reviewer: this.state.reviewer,
-      contributor: this.state.contributor
+      accessor: this.state.selectedPermission === "VIEW",
+      reviewer: this.state.selectedPermission === "MANAGE",
+      contributor: this.state.selectedPermission === "CONTRIBUTE"
     });
 
     await this.props.LoadGroups();
@@ -102,27 +100,54 @@ class ContentLibraryGroupForm extends React.Component {
             >
               <div className="form-content">
                 { this.Groups() }
+              </div>
 
-                <label htmlFor="accessor">Viewer</label>
+              <div className="radio-item">
                 <input
-                  type="checkbox"
-                  checked={this.state.accessor}
-                  onChange={() => this.setState({accessor: !this.state.accessor})}
+                  type="radio"
+                  id="view"
+                  checked={this.state.selectedPermission === "VIEW"}
+                  value={this.state.selectedPermission === "VIEW"}
+                  onChange={() => this.setState({selectedPermission: "VIEW"})}
                 />
+                <div className="radio-label">
+                  <label htmlFor="view">View</label>
+                  <div className="radio-helper-text">
+                    List content objects in the library. View library metadata.
+                  </div>
+                </div>
+              </div>
 
-                <label htmlFor="contributor">Contributor</label>
+              <div className="radio-item">
                 <input
-                  type="checkbox"
-                  checked={this.state.contributor}
-                  onChange={() => this.setState({contributor: !this.state.contributor})}
+                  type="radio"
+                  id="contribute"
+                  checked={this.state.selectedPermission === "CONTRIBUTE"}
+                  value={this.state.selectedPermission === "CONTRIBUTE"}
+                  onChange={() => this.setState({selectedPermission: "CONTRIBUTE"})}
                 />
+                <div className="radio-label">
+                  <label htmlFor="contribute">Contribute</label>
+                  <div className="radio-helper-text">
+                    List and create new content objects in the library. View library metadata.
+                  </div>
+                </div>
+              </div>
 
-                <label htmlFor="reviewer">Reviewer</label>
+              <div className="radio-item">
                 <input
-                  type="checkbox"
-                  checked={this.state.reviewer}
-                  onChange={() => this.setState({reviewer: !this.state.reviewer})}
+                  type="radio"
+                  id="manage"
+                  checked={this.state.selectedPermission === "MANAGE"}
+                  value={this.state.selectedPermission === "MANAGE"}
+                  onChange={() => this.setState({selectedPermission: "MANAGE"})}
                 />
+                <div className="radio-label">
+                  <label htmlFor="manage">Manage</label>
+                  <div className="radio-helper-text">
+                    List, create and delete content objects in the library. Edit library metadata.
+                  </div>
+                </div>
               </div>
             </Form>
           )}

--- a/src/components/pages/content/ContentLibraryGroupForm.js
+++ b/src/components/pages/content/ContentLibraryGroupForm.js
@@ -27,7 +27,7 @@ class ContentLibraryGroupForm extends React.Component {
     this.setState({
       groupAddress: event.target.value,
       selectedPermission: (
-        permissions.reviewer ? "MANAGE" : permissions.contributor ? "CONTRIBUTE" : permissions.accessor ? "VIEW" : ""
+        permissions.manage ? "MANAGE" : permissions.contributor ? "CONTRIBUTE" : permissions.accessor ? "VIEW" : ""
       )
     });
   }
@@ -37,7 +37,7 @@ class ContentLibraryGroupForm extends React.Component {
       libraryId: this.props.libraryStore.libraryId,
       groupAddress: this.state.groupAddress,
       accessor: this.state.selectedPermission === "VIEW",
-      reviewer: this.state.selectedPermission === "MANAGE",
+      manage: this.state.selectedPermission === "MANAGE",
       contributor: this.state.selectedPermission === "CONTRIBUTE"
     });
 

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -866,7 +866,14 @@ class ContentObject extends React.Component {
           {
             label: "Delete",
             type: "button",
-            hidden: this.props.objectStore.object.isContentLibraryObject || !this.props.objectStore.object.canEdit || !this.props.objectStore.object.isOwner,
+            hidden: (
+              this.props.objectStore.object.isContentLibraryObject ||
+              !(
+                this.props.objectStore.object.canEdit ||
+                this.props.objectStore.object.isOwner ||
+                this.props.libraryStore.library.isManager
+              )
+            ),
             onClick: () => this.DeleteContentObject(),
             className: "danger",
             dividerAbove: true

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -868,11 +868,8 @@ class ContentObject extends React.Component {
             type: "button",
             hidden: (
               this.props.objectStore.object.isContentLibraryObject ||
-              !(
-                this.props.objectStore.object.canEdit ||
-                this.props.objectStore.object.isOwner ||
-                this.props.libraryStore.library.isManager
-              )
+              (this.props.objectStore.object.isV3 && !this.props.libraryStore.library.isManager && !this.props.objectStore.object.canEdit) ||
+              (!this.props.objectStore.object.isV3 && !this.props.objectStore.object.isOwner)
             ),
             onClick: () => this.DeleteContentObject(),
             className: "danger",

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -868,7 +868,7 @@ class ContentObject extends React.Component {
             type: "button",
             hidden: (
               this.props.objectStore.object.isContentLibraryObject ||
-              (this.props.objectStore.object.isV3 && !this.props.libraryStore.library.isManager && !this.props.objectStore.object.canEdit) ||
+              (this.props.objectStore.object.isV3 && !this.props.libraryStore.library.isManager) ||
               (!this.props.objectStore.object.isV3 && !this.props.objectStore.object.isOwner)
             ),
             onClick: () => this.DeleteContentObject(),

--- a/src/components/pages/content/ContentObjectGroups.js
+++ b/src/components/pages/content/ContentObjectGroups.js
@@ -71,6 +71,8 @@ class ContentObjectGroups extends React.Component {
     if(this.state.listingRef) {
       this.state.listingRef.Load();
     }
+
+    this.setState({pageVersion: this.state.pageVersion + 1});
   }
 
   AccessGroups() {

--- a/src/static/stylesheets/forms.scss
+++ b/src/static/stylesheets/forms.scss
@@ -108,6 +108,32 @@ form {
   }
 }
 
+.-elv-form {
+  input {
+    &[type="radio"] {
+      cursor: pointer;
+      height: 100%;
+      margin: 3px 0 0;
+      width: 1rem;
+    }
+  }
+}
+
+.radio-item {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: row;
+  gap: 2rem; // sass-lint:disable-line no-misspelled-properties
+  margin-bottom: 1rem;
+
+  .radio-helper-text {
+    color: $elv-color-text-lighter;
+    font-size: $elv-font-m;
+    margin-top: $elv-spacing-xxs;
+  }
+}
+
+
 fieldset {
   display: flex;
   flex-direction: column;

--- a/src/stores/Library.js
+++ b/src/stores/Library.js
@@ -57,10 +57,11 @@ class LibraryStore {
         Fabric.AccessGroupAddresses()
       ]);
 
+      const canContribute = yield Fabric.CheckLibraryCanContribute({libraryId});
+
       this.libraries[libraryId].canContribute =
         this.libraries[libraryId].isOwner ||
-        (contributorGroups.filter(address => userGroups.includes(address))).length > 0;
-
+        (contributorGroups.filter(address => userGroups.includes(address))).length > 0 || canContribute;
     }
   });
 

--- a/src/stores/Library.js
+++ b/src/stores/Library.js
@@ -290,12 +290,30 @@ class LibraryStore {
           } else {
             await Fabric.AddContentLibraryGroup({libraryId, address: groupAddress, groupType: type});
           }
+
+          if(type === "contributor") {
+            await Fabric.SetContentLibraryRights({
+              libraryId,
+              address: groupAddress,
+              type: "ACCESS",
+              access: 1
+            });
+          }
         } else if(permissions[type] && !options[type]) {
           // Remove group
           if(type === "manage") {
             await Fabric.RemoveContentLibraryManagerGroup({libraryId, address: groupAddress});
           } else {
             await Fabric.RemoveContentLibraryGroup({libraryId, address: groupAddress, groupType: type});
+          }
+
+          if(type === "contributor") {
+            await Fabric.SetContentLibraryRights({
+              libraryId,
+              address: groupAddress,
+              type: "ACCESS",
+              access: 0
+            });
           }
         }
       })

--- a/src/stores/Library.js
+++ b/src/stores/Library.js
@@ -242,6 +242,20 @@ class LibraryStore {
   });
 
   @action.bound
+  RemoveContentLibraryGroup = flow(function * ({libraryId, groupAddress, type}) {
+    yield Fabric.RemoveContentLibraryGroup({
+      libraryId,
+      address: groupAddress,
+      groupType: type
+    });
+
+    this.rootStore.notificationStore.SetNotificationMessage({
+      message: "Successfully removed library group permissions",
+      redirect: true
+    });
+  });
+
+  @action.bound
   UpdateContentLibraryGroup = flow(function * ({libraryId, groupAddress, accessor, contributor, reviewer}) {
     const options = { accessor, contributor, reviewer};
 

--- a/src/stores/Library.js
+++ b/src/stores/Library.js
@@ -242,7 +242,7 @@ class LibraryStore {
   });
 
   @action.bound
-  RemoveContentLibraryGroup = flow(function * ({libraryId, groupAddress, type}) {
+  RemoveContentLibraryGroupPermission = flow(function * ({libraryId, groupAddress, type}) {
     yield Fabric.RemoveContentLibraryGroup({
       libraryId,
       address: groupAddress,

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -11,7 +11,6 @@ const concurrentUploads = 3;
 
 class ObjectStore {
   @observable writeTokens = {};
-  @observable forceUpdate = 0;
 
   @computed get libraryId() {
     return this.rootStore.routerStore.libraryId;
@@ -29,7 +28,6 @@ class ObjectStore {
   @computed get objectGroupPermissions() {
     const object = this.objects[this.objectId];
     // eslint-disable-next-line no-unused-vars
-    const _ = this.forceUpdate;
 
     return object ? object.groupPermissions : undefined;
   }
@@ -44,10 +42,6 @@ class ObjectStore {
     // Don't store objects in observable, it's very slow for large amounts of meta
     this.objects = {};
     this.versions = {};
-  }
-
-  forceComputedUpdate() {
-    this.forceUpdate += 1;
   }
 
   @action.bound
@@ -88,7 +82,6 @@ class ObjectStore {
   @action.bound
   ContentObjectGroupPermissions = flow(function * ({objectId}) {
     this.objects[objectId].groupPermissions = yield Fabric.GetContentObjectGroupPermissions({objectId});
-    this.forceComputedUpdate();
   });
 
   @action.bound


### PR DESCRIPTION
Update labels:
  Viewer -> View
  Contributor -> Contribute
  Reviewer -> Manage

Change checkbox inputs to radio inputs, making a single permission value selectable.
  NOTE: Since library groups may have multiple permissions, I'm adhering to the current design of having multiple values in the metadata. When loading the permissions, the app will display the highest permission level found. If "reviewer" and "contributor" are found, it will save the "reviewer" value and display Manage. When saving, it will only save one value and delete any other existing permissions (applies to old group permissions).

Add remove button to the table of all group permissions:
- Content Library (new)
- Content Object (new)
- Access Group (existing/tested)
- Content Types (new)

Design note: The radio input is a new component in Frowser. I kept the design consistent with the checkboxes in the other Group Permissions modals.

![scrnli_10_31_2023_12-09-13 PM](https://github.com/eluv-io/elv-fabric-browser/assets/91760982/4b4eae04-07e0-40c3-b9a6-c230484d515f)


Relates to #80 