### PR TITLE
Add library safety check, use publicOnly ContentType when no user access

### DIFF
--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -806,15 +806,19 @@ const Fabric = {
       methodArgs: [Fabric.currentAccountAddress]
     });
 
-    const hasContentTypeAccess = await client.CallContractMethod({
-      contractAddress: walletAddress,
-      methodName: "checkRights",
-      methodArgs: [
-        4, // CATEGORY_CONTENT_TYPE = 4
-        client.utils.HashToAddress(Fabric.utils.DecodeVersionHash(object.type).objectId),
-        1 // TYPE_SEE = 0; TYPE_ACCESS = 1; TYPE_EDIT = 2
-      ]
-    });
+
+    let hasContentTypeAccess = false;
+    if(object.type) {
+      hasContentTypeAccess = await client.CallContractMethod({
+        contractAddress: walletAddress,
+        methodName: "checkRights",
+        methodArgs: [
+          4, // CATEGORY_CONTENT_TYPE = 4
+          client.utils.HashToAddress(Fabric.utils.DecodeVersionHash(object.type).objectId),
+          1 // TYPE_SEE = 0; TYPE_ACCESS = 1; TYPE_EDIT = 2
+        ]
+      });
+    }
 
     let typeInfo;
     if(object.type) {

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -868,7 +868,7 @@ class ContentObject extends React.Component {
             type: "button",
             hidden: (
               this.props.objectStore.object.isContentLibraryObject ||
-              (this.props.objectStore.object.isV3 && this.props.libraryStore.library && !this.props.libraryStore.library.isManager) ||
+              (this.props.objectStore.object.isV3 && !this.props.libraryStore.library || !this.props.libraryStore.library.isManager) ||
               (!this.props.objectStore.object.isV3 && !this.props.objectStore.object.isOwner)
             ),
             onClick: () => this.DeleteContentObject(),

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -868,7 +868,7 @@ class ContentObject extends React.Component {
             type: "button",
             hidden: (
               this.props.objectStore.object.isContentLibraryObject ||
-              (this.props.objectStore.object.isV3 && !this.props.libraryStore.library.isManager) ||
+              (this.props.objectStore.object.isV3 && this.props.libraryStore.library && !this.props.libraryStore.library.isManager) ||
               (!this.props.objectStore.object.isV3 && !this.props.objectStore.object.isOwner)
             ),
             onClick: () => this.DeleteContentObject(),

--- a/src/stores/Library.js
+++ b/src/stores/Library.js
@@ -254,6 +254,16 @@ class LibraryStore {
 
   @action.bound
   RemoveContentLibraryGroupPermission = flow(function * ({libraryId, groupAddress, type}) {
+    if(type === "contributor") {
+      // Remove access before deleting since this is manually added
+      yield Fabric.SetContentLibraryRights({
+        libraryId,
+        address: groupAddress,
+        type: "ACCESS",
+        access: 0
+      });
+    }
+
     if(type === "manage") {
       yield Fabric.RemoveContentLibraryManagerGroup({libraryId, address: groupAddress});
     } else {


### PR DESCRIPTION
When a user has access to an object through a group but no access to the library or content type, the Fabric Browser breaks in two ways:
- The code is looking for a property on an object that is undefined (library)
- client ContentType fails because the user doesn't have access to the content type

This adds a simple check for the library and checks the user's access rights to the content type. If they have no access, ContentType is called with the `publicOnly` flag.