### PR TITLE
Add transfer ownership logic

### DIFF
--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -964,6 +964,36 @@ const Fabric = {
     };
   },
 
+  GetContentObjectCaps: async({
+    libraryId,
+    objectId
+  }) => {
+    const hasCaps = await client.HasCaps({
+      libraryId,
+      objectId
+    });
+    let hasCapsForOwner = false;
+
+    if(hasCaps) {
+      // Check for owner cap
+      const contentOwner = await client.ContentObjectOwner({
+        libraryId,
+        objectId
+      });
+
+      hasCapsForOwner = await client.HasCapsForUser({
+        libraryId,
+        objectId,
+        userAddress: contentOwner
+      });
+    }
+
+    return {
+      hasCaps,
+      hasCapsForOwner
+    };
+  },
+
   GetContentObjectMetadata: async ({
     libraryId,
     objectId,
@@ -1249,7 +1279,7 @@ const Fabric = {
       libraryId,
       objectId,
       writeToken,
-      commitMessage: "Transferred ownership",
+      commitMessage: "Transfer ownership",
       awaitCommitConfirmation: true
     });
   },

--- a/src/clients/Fabric.js
+++ b/src/clients/Fabric.js
@@ -1080,7 +1080,16 @@ const Fabric = {
   },
 
   GetContentObjectOwner: async ({objectId}) => {
-    return FormatAddress(await client.ContentObjectOwner({objectId}));
+    try {
+      return Fabric.utils.FormatAddress(
+        await client.CallContractMethod({
+          contractAddress: Fabric.client.utils.HashToAddress(objectId),
+          methodName: "owner"
+        })
+      );
+    } catch(_e) {
+      return FormatAddress(await client.ContentObjectOwner({objectId}));
+    }
   },
 
   GetAccessInfo: async ({objectId}) => {
@@ -1217,6 +1226,32 @@ const Fabric = {
     });
 
     return response;
+  },
+
+  TransferObjectOwnership: async({
+    libraryId,
+    objectId,
+    newPublicKey
+  }) => {
+    const {writeToken} = await client.EditContentObject({
+      libraryId,
+      objectId
+    });
+
+    await client.TransferOwnership({
+      libraryId,
+      objectId,
+      writeToken,
+      newOwnerPublicKey: newPublicKey
+    });
+
+    await client.FinalizeContentObject({
+      libraryId,
+      objectId,
+      writeToken,
+      commitMessage: "Transferred ownership",
+      awaitCommitConfirmation: true
+    });
   },
 
   FinalizeContentObject: async ({

--- a/src/components/components/Warnings.js
+++ b/src/components/components/Warnings.js
@@ -1,0 +1,28 @@
+import {warningStore} from "../../stores";
+import React from "react";
+import CloseIcon from "../../static/icons/close.svg";
+import {IconButton} from "elv-components-js";
+
+const Warnings = () => {
+  if(!warningStore.activeWarnings.length) { return null; }
+
+  return (
+    <div className="warnings-container">
+      {
+        warningStore.activeWarnings.map(warning => (
+          <div className="warning-box" key={warning.id}>
+            { warning.message }
+            <IconButton
+              className="clear-notification"
+              icon={CloseIcon}
+              label="clear-warning"
+              onClick={() => warningStore.DismissWarning(warning.id)}
+            />
+          </div>
+        ))
+      }
+    </div>
+  );
+};
+
+export default Warnings;

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -26,6 +26,7 @@ import DeleteIcon from "../../../static/icons/trash.svg";
 import Diff from "../../components/Diff";
 import {ContentBrowserModal} from "../../components/ContentBrowser";
 import ActionsToolbar from "../../components/ActionsToolbar";
+import Warnings from "../../components/Warnings";
 
 const DownloadPart = ({libraryId, objectId, versionHash, partHash, partName, DownloadMethod}) => {
   const [progress, setProgress] = useState(undefined);
@@ -1018,6 +1019,7 @@ class ContentObject extends React.Component {
       pageContent = (
         <React.Fragment>
           { this.Image() }
+          <Warnings />
           { this.ObjectInfo() }
         </React.Fragment>
       );
@@ -1147,6 +1149,17 @@ class ContentObject extends React.Component {
                 libraryId: this.props.objectStore.libraryId,
                 objectId: this.props.objectStore.objectId,
                 refresh: this.state.refresh
+              });
+            } catch(error) {
+              // eslint-disable-next-line no-console
+              console.error(error);
+              throw error;
+            }
+
+            try {
+              await this.props.objectStore.ContentObjectCaps({
+                libraryId: this.props.objectStore.libraryId,
+                objectId: this.props.objectStore.objectId
               });
             } catch(error) {
               // eslint-disable-next-line no-console

--- a/src/components/pages/content/ContentObject.js
+++ b/src/components/pages/content/ContentObject.js
@@ -82,6 +82,8 @@ class ContentObject extends React.Component {
       prevVersionsToggled: false,
       moreOptions: false,
       showCopyObjectModal: false,
+      showTransferOwnershipModal: false,
+      transferPublicKey: "",
       redirectIds: {},
       showNonOwnerCapManagement: false,
       newNonOwnerCapPublicKey: "",
@@ -867,6 +869,12 @@ class ContentObject extends React.Component {
             title: !(this.props.objectStore.object.isOwner || hasUserCap) ? "You don't have the key" : undefined
           },
           {
+            label: "Transfer Ownership",
+            type: "button",
+            onClick: () => this.setState({showTransferOwnershipModal: true}),
+            hidden: !(this.props.objectStore.object.isOwner)
+          },
+          {
             label: "Delete",
             type: "button",
             hidden: (
@@ -952,6 +960,19 @@ class ContentObject extends React.Component {
         objectId: id,
         libraryId: qlib_id
       }
+    });
+  }
+
+  TransferOwnership = async() => {
+    await this.props.objectStore.TransferObjectOwnership({
+      libraryId: this.props.objectStore.libraryId,
+      objectId: this.props.objectStore.objectId,
+      newPublicKey: this.state.transferPublicKey
+    });
+
+    this.setState({
+      showTransferOwnershipModal: false,
+      pageVersion: this.state.pageVersion + 1
     });
   }
 
@@ -1072,6 +1093,21 @@ class ContentObject extends React.Component {
               header="Select a library"
               confirmMessageCallback={({name, libraryName}) => `Are you sure you want to copy ${name} into ${libraryName}?`}
             /> : null
+        }
+        {
+          this.state.showTransferOwnershipModal &&
+          <Modal OnClickOutside={() => this.setState({showTransferOwnershipModal: false})}>
+            <Form
+              legend="Transfer Ownership"
+              OnCancel={() => this.setState({showTransferOwnershipModal: false})}
+              OnSubmit={() => this.TransferOwnership()}
+            >
+              <div className="form-content">
+                <label htmlFor="publicKey">Public Key</label>
+                <textarea name="publicKey" value={this.state.transferPublicKey} onChange={(event) => this.setState({transferPublicKey: event.target.value})} style={{height: "6rem"}} />
+              </div>
+            </Form>
+          </Modal>
         }
       </div>
     );

--- a/src/static/stylesheets/app.scss
+++ b/src/static/stylesheets/app.scss
@@ -14,3 +14,4 @@
 @import "forms";
 @import "content_browser";
 @import "search_form";
+@import "warnings";

--- a/src/static/stylesheets/content.scss
+++ b/src/static/stylesheets/content.scss
@@ -21,9 +21,9 @@
   max-width: 100%;
 
   .missing-caps-warning {
-    padding: 10px;
-    background-color: rgba(#ffdd00, 0.4);
+    background-color: rgba(#fd0, 0.4);
     margin-bottom: 10px;
+    padding: 10px;
   }
 }
 
@@ -240,9 +240,9 @@ pre,
   }
 
   .missing-caps-warning {
-    padding: 10px;
-    background-color: rgba(#ffdd00, 0.4);
+    background-color: rgba(#fd0, 0.4);
     margin-bottom: 10px;
+    padding: 10px;
   }
 }
 

--- a/src/static/stylesheets/content.scss
+++ b/src/static/stylesheets/content.scss
@@ -19,6 +19,12 @@
 
 .object-info {
   max-width: 100%;
+
+  .missing-caps-warning {
+    padding: 10px;
+    background-color: rgba(#ffdd00, 0.4);
+    margin-bottom: 10px;
+  }
 }
 
 .object-image {
@@ -231,6 +237,12 @@ pre,
     font-size: .9rem;
     padding-bottom: 15px;
     padding-top: 15px;
+  }
+
+  .missing-caps-warning {
+    padding: 10px;
+    background-color: rgba(#ffdd00, 0.4);
+    margin-bottom: 10px;
   }
 }
 

--- a/src/static/stylesheets/warnings.scss
+++ b/src/static/stylesheets/warnings.scss
@@ -4,17 +4,17 @@
   gap: 10px;
 
   .warning-box {
-    padding: 10px $elv-spacing-ss;
-    background-color: rgba(#ffdd00, 0.4);
-    margin-bottom: 10px;
+    background-color: rgba(#fd0, 0.4);
     display: flex;
     flex-direction: row;
+    margin-bottom: 10px;
+    padding: 10px $elv-spacing-ss;
 
     .clear-notification {
-      height: auto;
-      width: 20px;
       display: flex;
+      height: auto;
       margin-left: auto;
+      width: 20px;
     }
   }
 }

--- a/src/static/stylesheets/warnings.scss
+++ b/src/static/stylesheets/warnings.scss
@@ -1,0 +1,20 @@
+.warnings-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  .warning-box {
+    padding: 10px $elv-spacing-ss;
+    background-color: rgba(#ffdd00, 0.4);
+    margin-bottom: 10px;
+    display: flex;
+    flex-direction: row;
+
+    .clear-notification {
+      height: auto;
+      width: 20px;
+      display: flex;
+      margin-left: auto;
+    }
+  }
+}

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -300,6 +300,25 @@ class ObjectStore {
     return response;
   });
 
+  @action.bound TransferObjectOwnership = flow(function * ({libraryId, objectId, newPublicKey}) {
+    try {
+      yield Fabric.TransferObjectOwnership({
+        libraryId,
+        objectId,
+        newPublicKey
+      });
+
+      this.rootStore.notificationStore.SetNotificationMessage({
+        message: "Successfully transferred ownership",
+        redirect: true
+      });
+    } catch(error) {
+      // eslint-disable-next-line no-console
+      console.error("Unable to transfer ownership", error);
+      throw error;
+    }
+  });
+
   @action.bound
   FinalizeContentObject = flow(function * ({libraryId, objectId}) {
     const object = this.objects[objectId];

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -65,6 +65,25 @@ class ObjectStore {
   });
 
   @action.bound
+  ContentObjectCaps = flow(function * ({libraryId, objectId}) {
+    const {hasCaps, hasCapsForOwner} = yield Fabric.GetContentObjectCaps({
+      libraryId,
+      objectId
+    });
+
+    this.objects[objectId]._hasCaps = hasCaps;
+    this.objects[objectId]._hasCapsForOwner = hasCapsForOwner;
+
+    if(hasCaps && !hasCapsForOwner) {
+      this.rootStore.warningStore.AddWarning({
+        warningTitle: "MISSING_OWNER_CAP",
+        objectId,
+        message: "Warning: General CAPS are present, but owner CAPS are missing.",
+      });
+    }
+  });
+
+  @action.bound
   ContentObjectParts = flow(function * ({versionHash}) {
     if(this.versions[versionHash] && this.versions[versionHash].parts) { return; }
 

--- a/src/stores/WarningStore.js
+++ b/src/stores/WarningStore.js
@@ -1,0 +1,72 @@
+import {action, computed, observable} from "mobx";
+
+const DISMISSED_WARNINGS_KEY = "app_dismissed_warnings";
+const ID_PREFIX = "WARN_";
+
+class WarningStore {
+  @observable dismissedIds = {};
+  @observable currentWarnings = {};
+
+  constructor(rootStore) {
+    this.rootStore = rootStore;
+    this.LoadDismissedIds();
+  }
+
+  @action
+  AddWarning({warningTitle, objectId, message}) {
+    const uniqueId = `${ID_PREFIX}${warningTitle}_${objectId}`;
+
+    if(!this.currentWarnings[uniqueId]) {
+      this.currentWarnings[uniqueId] = {
+        objectId,
+        message: message,
+        title: warningTitle,
+        id: uniqueId
+      };
+    }
+  }
+
+  @action
+  RemoveWarning(warningId) {
+    if(this.currentWarnings.hasOwnProperty(warningId)) {
+      delete this.currentWarnings[warningId];
+    }
+  }
+
+  @action
+  DismissWarning(warningId) {
+    this.dismissedIds[warningId] = true;
+    this.SaveDismissedIds();
+  }
+
+  @computed
+  get activeWarnings() {
+    return Object.values(this.currentWarnings)
+      .filter(warning => !this.dismissedIds[warning.id]);
+  }
+
+  @action
+  LoadDismissedIds() {
+    try {
+      const storedData = localStorage.getItem(DISMISSED_WARNINGS_KEY);
+
+      if(storedData) {
+        this.dismissedIds = JSON.parse(storedData);
+      }
+    } catch(error) {
+      // eslint-disable-next-line no-console
+      console.error("Could not load dismissed IDs from localStorage", error);
+    }
+  }
+
+  SaveDismissedIds() {
+    try {
+      localStorage.setItem(DISMISSED_WARNINGS_KEY, JSON.stringify(this.dismissedIds));
+    } catch(error) {
+      // eslint-disable-next-line no-console
+      console.error("Unable to save dismissed notifications to localStorage", error);
+    }
+  }
+}
+
+export default WarningStore;

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -10,6 +10,7 @@ import TypeStore from "./Type";
 import ObjectStore from "./Object";
 import NotificationStore from "./Notifications";
 import ContentStore from "./Content";
+import WarningStore from "./WarningStore";
 
 // Force strict mode so mutations are only allowed within actions.
 configure({
@@ -32,6 +33,7 @@ class RootStore {
     this.routerStore = new RouterStore(this);
     this.typeStore = new TypeStore(this);
     this.contentStore = new ContentStore(this);
+    this.warningStore = new WarningStore(this);
   }
 
   @action.bound
@@ -57,5 +59,6 @@ export const objectStore = rootStore.objectStore;
 export const routeStore = rootStore.routerStore;
 export const typeStore = rootStore.typeStore;
 export const contentStore = rootStore.contentStore;
+export const warningStore = rootStore.warningStore;
 
 window.rootStore = rootStore;


### PR DESCRIPTION
- Add **Transfer Ownership** button to Content Objects
- Display a warning to the user based on this flow:
  - When Content Object page loads, check for existing CAPS. If there are CAPS, but they do not include one for the owner, dispay a warning.
- Add warning system:
  - Warning component (similar to Notifications)
  - WarningStore (creating/managing warnings)
  - Warnings are cached in mobx
  - Save warnings that have been dismissed so that the UI can only show active warnings. Warnings have IDs formatted as `WARN_<TITLE>_<OBJECT_ID>`