### PR TITLE
Remove write token from meta read after index finalize

### DIFF
--- a/src/components/pages/content/SearchConfiguration.js
+++ b/src/components/pages/content/SearchConfiguration.js
@@ -201,12 +201,7 @@ const SearchConfiguration = observer((props) => {
   const UpdateIndex = async () => {
     const {libraryId, objectId} = objectStore;
     const rootObjectId = (
-      objectStore.object.meta &&
-      objectStore.object.meta.indexer &&
-      objectStore.object.meta.indexer.config &&
-      objectStore.object.meta.indexer.config.fabric &&
-      objectStore.object.meta.indexer.config.fabric.root &&
-      objectStore.object.meta.indexer.config.fabric.root.content
+      objectStore.object.meta?.indexer?.config?.fabric?.root?.content
     );
 
     const lastRunHash = await objectStore.GetContentObjectMetadata({

--- a/src/stores/Object.js
+++ b/src/stores/Object.js
@@ -923,7 +923,6 @@ MergeMetadata = flow(function * ({
     this.objects[objectId].meta = yield Fabric.GetContentObjectMetadata({
       libraryId,
       objectId,
-      writeToken,
       service: "search"
     });
 


### PR DESCRIPTION
Remove write token from metadata read after object finalization has finished. This read updates the cached object and likely came before the finalize operation.